### PR TITLE
Use python3 as all scripts are in python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper (>= 9),
                libglib2.0-dev (>= 2.37.3),
                libgtk-3-dev (>= 3.3.16),
                libx11-dev,
-               python,
+               python3,
                yelp-tools,
                libgnomekbd-dev
 Standards-Version: 3.9.6
@@ -25,7 +25,7 @@ Standards-Version: 3.9.6
 Package: xapps-common
 Architecture: all
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${python:Depends}, python3, python3-gi, inxi, xdg-utils, gist
+Depends: ${misc:Depends}, ${python3:Depends}, python3, python3-gi, inxi, xdg-utils, gist
 Description: Common files for XApp desktop apps
  This package includes files that are shared between several XApp
  apps (i18n files and configuration schemas).

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 DEB_PKG_CONFIG_LIBDIR=$(shell pkg-config gobject-introspection-1.0 --variable libdir | sed -e 's/.//')
 
 %:
-	dh $@ --parallel --with=autoreconf,gir,gnome,python2
+	dh $@ --parallel --with=autoreconf,gir,gnome,python3
 
 override_dh_gnome_clean:
 	dh_gnome_clean --no-control


### PR DESCRIPTION
Taken from https://anonscm.debian.org/git/pkg-cinnamon/xapp.git/commit/?id=e121aaa12eb469206f452755992d6ee211d46425