### PR TITLE
Add media-mount-symbolic icon

### DIFF
--- a/files/usr/share/icons/hicolor/scalable/actions/media-mount-symbolic.svg
+++ b/files/usr/share/icons/hicolor/scalable/actions/media-mount-symbolic.svg
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="media-mount-symbolic.svg">
+  <defs
+     id="defs7667" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1280"
+     inkscape:window-height="745"
+     id="namedview7665"
+     showgrid="true"
+     inkscape:zoom="16"
+     inkscape:cx="6.9181492"
+     inkscape:cy="4.2111319"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4147"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4138" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Gnome Symbolic Icon Theme</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title9167">Gnome Symbolic Icon Theme</title>
+  <g
+     id="g4147"
+     style="fill:#bebebe;fill-opacity:1;stroke:none"
+     transform="matrix(1.3889016,0,0,1.3889016,-3.0103731,-3.5159478)">
+    <g
+       id="g4551">
+      <path
+         inkscape:connector-curvature="0"
+         d="M 12.247433,10.451386 H 3.6075116 v 1.439987 h 8.6399214 z"
+         id="path3807-1-1-9-3-0-9"
+         sodipodi:nodetypes="ccccc"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;stroke:none;stroke-width:1.43998682;marker:none;enable-background:accumulate" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#bebebe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.43998682;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="sccccccccccs"
+         id="path3807-1-1-9-8-4"
+         d="m 7.927328,9.0113995 c -0.1915038,0 -0.3838788,-0.064151 -0.5174952,-0.2024982 L 3.8098657,5.2089343 C 3.6974028,5.0943905 3.6246474,4.9411687 3.6073676,4.7814382 V 4.691439 3.9714456 H 12.247289 V 4.691439 4.781438 c -0.01728,0.1597305 -0.09004,0.3129523 -0.202499,0.4274961 L 8.4448233,8.8089013 C 8.3112069,8.9472265 8.1188319,9.0113995 7.927328,9.0113995 Z"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Inspired by the `media-mount-symbolic` icon from the Breeze icon theme.
Based on the `media-eject-symbolic` icon from the Adwaita icon theme.

Use case: Right-click action to mount devices in nemo