### PR TITLE
Make XAppPreferencesWindow appearance more consistent with other dialogs

### DIFF
--- a/libxapp/xapp-preferences-window.c
+++ b/libxapp/xapp-preferences-window.c
@@ -17,7 +17,6 @@ typedef struct
     GtkWidget    *stack;
     GtkWidget    *side_switcher;
     GtkWidget    *button_area;
-    GtkSizeGroup *button_size_group;
 
     gint          num_pages;
 } XAppPreferencesWindowPrivate;
@@ -66,8 +65,6 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     priv->button_area = gtk_action_bar_new ();
     gtk_box_pack_start (GTK_BOX (main_box), priv->button_area, FALSE, FALSE, 0);
     gtk_widget_set_no_show_all (priv->button_area, TRUE);
-
-    priv->button_size_group = gtk_size_group_new (GTK_SIZE_GROUP_HORIZONTAL);
 
     /* Keep track of the number of pages so we can hide the stack switcher with < 2 */
     priv->num_pages = 0;
@@ -183,6 +180,5 @@ xapp_preferences_window_add_button (XAppPreferencesWindow *window,
     style_context = gtk_widget_get_style_context (button);
     gtk_style_context_add_class (style_context, "text-button");
 
-    gtk_size_group_add_widget (priv->button_size_group, button);
     gtk_widget_set_no_show_all (priv->button_area, FALSE);
 }

--- a/libxapp/xapp-preferences-window.c
+++ b/libxapp/xapp-preferences-window.c
@@ -38,6 +38,7 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     XAppPreferencesWindowPrivate *priv = xapp_preferences_window_get_instance_private (window);
     GtkWidget *main_box;
     GtkWidget *secondary_box;
+    GtkStyleContext *style_context;
 
     gtk_window_set_default_size (GTK_WINDOW (window), 600, 400);
     gtk_window_set_skip_taskbar_hint (GTK_WINDOW (window), TRUE);
@@ -58,6 +59,9 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     gtk_stack_set_transition_type (GTK_STACK (priv->stack), GTK_STACK_TRANSITION_TYPE_CROSSFADE);
     gtk_box_pack_start (GTK_BOX (secondary_box), priv->stack, TRUE, TRUE, 0);
     gtk_stack_sidebar_set_stack (GTK_STACK_SIDEBAR (priv->side_switcher), GTK_STACK (priv->stack));
+
+    style_context = gtk_widget_get_style_context (priv->stack);
+    gtk_style_context_add_class (style_context, "view");
 
     priv->button_area = gtk_action_bar_new ();
     gtk_box_pack_start (GTK_BOX (main_box), priv->button_area, FALSE, FALSE, 0);

--- a/libxapp/xapp-preferences-window.c
+++ b/libxapp/xapp-preferences-window.c
@@ -42,12 +42,18 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     gtk_window_set_default_size (GTK_WINDOW (window), 600, 400);
     gtk_window_set_skip_taskbar_hint (GTK_WINDOW (window), TRUE);
     gtk_window_set_type_hint (GTK_WINDOW (window), GDK_WINDOW_TYPE_HINT_DIALOG);
+    gtk_container_set_border_width (GTK_CONTAINER(window), 5);
 
     main_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 0);
+    gtk_container_set_border_width (GTK_CONTAINER(main_box), 2);
     gtk_container_add (GTK_CONTAINER (window), main_box);
 
     secondary_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+    gtk_container_set_border_width (GTK_CONTAINER(secondary_box), 5);
     gtk_box_pack_start (GTK_BOX (main_box), secondary_box, TRUE, TRUE, 0);
+
+    style_context = gtk_widget_get_style_context (secondary_box);
+    gtk_style_context_add_class (style_context, "frame");
 
     priv->side_switcher = gtk_stack_sidebar_new ();
     gtk_widget_set_size_request (priv->side_switcher, 100, -1);
@@ -63,6 +69,7 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     gtk_style_context_add_class (style_context, "view");
 
     priv->button_area = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
+    gtk_container_set_border_width (GTK_CONTAINER(priv->button_area), 5);
     gtk_box_pack_start (GTK_BOX (main_box), priv->button_area, FALSE, FALSE, 0);
     gtk_widget_set_no_show_all (priv->button_area, TRUE);
 

--- a/libxapp/xapp-preferences-window.c
+++ b/libxapp/xapp-preferences-window.c
@@ -62,7 +62,7 @@ xapp_preferences_window_init (XAppPreferencesWindow *window)
     style_context = gtk_widget_get_style_context (priv->stack);
     gtk_style_context_add_class (style_context, "view");
 
-    priv->button_area = gtk_action_bar_new ();
+    priv->button_area = gtk_button_box_new (GTK_ORIENTATION_HORIZONTAL);
     gtk_box_pack_start (GTK_BOX (main_box), priv->button_area, FALSE, FALSE, 0);
     gtk_widget_set_no_show_all (priv->button_area, TRUE);
 
@@ -162,17 +162,13 @@ xapp_preferences_window_add_button (XAppPreferencesWindow *window,
     g_return_if_fail (XAPP_IS_PREFERENCES_WINDOW (window));
     g_return_if_fail (GTK_IS_WIDGET (button));
 
-    if (pack_type == GTK_PACK_START)
+    gtk_container_add (GTK_CONTAINER (priv->button_area), button);
+
+    if (pack_type == GTK_PACK_END)
     {
-        gtk_action_bar_pack_start (GTK_ACTION_BAR (priv->button_area), button);
-        gtk_widget_set_margin_start (button, 6);
+        gtk_button_box_set_child_secondary (GTK_BUTTON_BOX (priv->button_area), button, TRUE);
     }
-    else if (pack_type == GTK_PACK_END)
-    {
-        gtk_action_bar_pack_end (GTK_ACTION_BAR (priv->button_area), button);
-        gtk_widget_set_margin_end (button, 6);
-    }
-    else
+    else if (pack_type != GTK_PACK_START)
     {
         return;
     }


### PR DESCRIPTION
This pull request makes XAppPreferencesWindow more consistent with GTK built-in dialogs and other applications dialogs. It adds margin, frame and makes buttons sizes proper. See screenshots (Adwaita, Arc, Numix as examples). I opened font chooser dialog for comparison.

Before: 
![before_adwaita](https://user-images.githubusercontent.com/1395027/43051010-66c97520-8e12-11e8-98c7-ebed886c0094.png)
![before_numix](https://user-images.githubusercontent.com/1395027/43051012-6ebd3244-8e12-11e8-8770-846bd733e0b8.png)
![before_arc](https://user-images.githubusercontent.com/1395027/43051014-7598b5d4-8e12-11e8-9781-31b7be228bef.png)

After:
![after_adwaita](https://user-images.githubusercontent.com/1395027/43051018-7df847f8-8e12-11e8-817e-679d680359bf.png)
![after_numix](https://user-images.githubusercontent.com/1395027/43051019-84893dfc-8e12-11e8-99a5-53c5389dddff.png)
![after_arc](https://user-images.githubusercontent.com/1395027/43051021-8ca37476-8e12-11e8-9ef2-4c9f80837950.png)


