### PR TITLE
stack-sidear: Simplify a bit

### DIFF
--- a/libxapp/xapp-glade-catalog.c
+++ b/libxapp/xapp-glade-catalog.c
@@ -2,6 +2,7 @@
 #include <glib-object.h>
 
 #include "xapp-gtk-window.h"
+#include "xapp-stack-sidebar.h"
 
 void
 xapp_glade_catalog_init (const gchar *catalog_name);
@@ -10,4 +11,5 @@ void
 xapp_glade_catalog_init (const gchar *catalog_name)
 {
   g_type_ensure (XAPP_TYPE_GTK_WINDOW);
+  g_type_ensure (XAPP_TYPE_STACK_SIDEBAR);
 }

--- a/libxapp/xapp-glade-catalog.xml
+++ b/libxapp/xapp-glade-catalog.xml
@@ -4,9 +4,12 @@
   <glade-widget-classes>
     <glade-widget-class name="XAppGtkWindow" generic-name="xappgtkwindow"
           title="XAppGtkWindow" parent="GtkWindow" />
+    <glade-widget-class name="XAppStackSidebar" generic-name="xappstacksidebar"
+          title="XAppStackSidebar" />
   </glade-widget-classes>
 
   <glade-widget-group name="xapp-widgets" title="XApp Widgets">
     <glade-widget-class-ref name="XAppGtkWindow" />
+    <glade-widget-class-ref name="XAppStackSidebar" />
   </glade-widget-group>
 </glade-catalog>

--- a/libxapp/xapp-stack-sidebar.h
+++ b/libxapp/xapp-stack-sidebar.h
@@ -10,7 +10,7 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (XAppStackSidebar, xapp_stack_sidebar, XAPP, STACK_SIDEBAR, GtkBin)
 
-XAppStackSidebar *xapp_stack_sidebar_new (GtkOrientation orientation);
+XAppStackSidebar *xapp_stack_sidebar_new (void);
 
 void xapp_stack_sidebar_set_stack (XAppStackSidebar *sidebar,
                                    GtkStack         *stack);

--- a/pygobject/XApp.py
+++ b/pygobject/XApp.py
@@ -21,5 +21,10 @@ __all__ = []
 class GtkWindow(XApp.GtkWindow):
     pass
 
+class GtkBin(XApp.StackSidebar):
+    pass
+
 GtkWindow = override(GtkWindow)
+GtkBin = override(GtkBin)
 __all__.append('GtkWindow')
+__all__.append('GtkBin')


### PR DESCRIPTION
Since we chose the horizontal layout as the preferred style, remove the
support for vertical layouts. This simplifies things a bit. Also remove
inserting a separator between each row.