### PR TITLE
icon chooser dialog: Prevent the dialog from being destroyed when the…

### DIFF
--- a/libxapp/xapp-icon-chooser-dialog.c
+++ b/libxapp/xapp-icon-chooser-dialog.c
@@ -1207,6 +1207,8 @@ on_delete_event (GtkWidget   *widget,
                  GdkEventAny *event)
 {
     xapp_icon_chooser_dialog_close (XAPP_ICON_CHOOSER_DIALOG (widget), GTK_RESPONSE_CANCEL);
+
+    return TRUE;
 }
 
 static gboolean


### PR DESCRIPTION
… window close button is clicked. This was causing an issue where the dialog will not reopen in some cases.