### PR TITLE
xapp-icon-chooser-button.c: make dialog inherit modal state

### DIFF
--- a/libxapp/xapp-icon-chooser-button.c
+++ b/libxapp/xapp-icon-chooser-button.c
@@ -45,10 +45,13 @@ on_clicked (GtkButton *button)
 {
     XAppIconChooserButtonPrivate *priv;
     GtkResponseType               response;
+    GtkWidget *toplevel;
 
+    toplevel = gtk_widget_get_toplevel (GTK_WIDGET (button));
     priv = xapp_icon_chooser_button_get_instance_private (XAPP_ICON_CHOOSER_BUTTON (button));
 
-    gtk_window_set_transient_for (GTK_WINDOW (priv->dialog), GTK_WINDOW (gtk_widget_get_toplevel (GTK_WIDGET (button))));
+    gtk_window_set_transient_for (GTK_WINDOW (priv->dialog), GTK_WINDOW (toplevel));
+    gtk_window_set_modal (GTK_WINDOW (priv->dialog), gtk_window_get_modal (GTK_WINDOW (toplevel)));
 
     if (priv->icon_string == NULL)
     {


### PR DESCRIPTION
This makes the XAppIconChooserDialog inherit the modal state from the toplevel widget of the icon chooser button. This fixes an issue where the dialog is unresponsive when the button is pressed while in a modal window - such as the dialog that opens when adding a new entry to the editable list widget in Cinnamon's xlet settings.