### PR TITLE
Add an applet/monitor class for status icons

### DIFF
--- a/docs/xapp-docs.xml
+++ b/docs/xapp-docs.xml
@@ -24,6 +24,8 @@
     <xi:include href="xml/xapp-preferences-window.xml"/>
     <xi:include href="xml/xapp-stack-sidebar.xml"/>
     <xi:include href="xml/xapp-status-icon.xml"/>
+    <xi:include href="xml/xapp-status-icon-monitor.xml"/>
+    <xi:include href="xml/xapp-statusicon-interface.xml"/>
 
   </chapter>
   <chapter id="object-tree">

--- a/libxapp/g-codegen.py
+++ b/libxapp/g-codegen.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+'''
+FIXME
+
+This script is used only to call gdbus-codegen and simulate the
+generation of the source code and header as different targets.
+
+Both are generated implicitly, so meson is not able to know how
+many files are generated, so it does generate only one opaque
+target that represents the two files.
+
+originally from:
+https://gitlab.gnome.org/GNOME/gnome-settings-daemon/commit/5924d72931a030b24554116a48140a661a99652b
+
+Please see:
+   https://bugzilla.gnome.org/show_bug.cgi?id=791015
+   https://github.com/mesonbuild/meson/pull/2930
+'''
+
+import subprocess
+import sys
+import os
+
+subprocess.call([
+  'gdbus-codegen',
+  '--interface-prefix=' + sys.argv[1],
+  '--generate-c-code=' + os.path.join(sys.argv[4], sys.argv[2]),
+  '--c-namespace=XApp',
+  '--annotate', sys.argv[1], 'org.gtk.GDBus.C.Name', sys.argv[3],
+  sys.argv[5]
+])

--- a/libxapp/meson.build
+++ b/libxapp/meson.build
@@ -18,6 +18,7 @@ xapp_headers = [
     'xapp-preferences-window.h',
     'xapp-stack-sidebar.h',
     'xapp-status-icon.h',
+    'xapp-status-icon-monitor.h'
 ]
 
 xapp_sources = [
@@ -30,7 +31,35 @@ xapp_sources = [
     'xapp-preferences-window.c',
     'xapp-stack-sidebar.c',
     'xapp-status-icon.c',
+    'xapp-status-icon-monitor.c'
 ]
+
+codegen = find_program('g-codegen.py')
+
+dbus_headers = []
+
+# FIXME: Ugly workaround that simulates the generation of
+#        two different targets, so headers can be included
+#        explicitly for introspection.
+# 
+# This can be removed once all platforms use meson >=.46
+# and replaced with gnome.gdbus_codegen
+generated_sources = custom_target(
+    'xapp-statusicon-interface',
+    input: 'org.x.StatusIcon.xml',
+    output: ['xapp-statusicon-interface.h', 'xapp-statusicon-interface.c'],
+    command: [
+        codegen,
+        'org.x.StatusIcon',
+        'xapp-statusicon-interface',
+        'StatusIconInterface',
+        meson.current_build_dir(),
+        '@INPUT@', '@OUTPUT@'
+    ]
+)
+
+dbus_headers += generated_sources[0]
+xapp_sources += generated_sources[1]
 
 xapp_enums = gnome.mkenums('xapp-enums',
     sources : xapp_headers,
@@ -41,12 +70,12 @@ xapp_enums = gnome.mkenums('xapp-enums',
 )
 
 libxapp = library('xapp',
-    sources  : xapp_headers + xapp_sources + xapp_enums,
+    sources  : xapp_headers + xapp_sources + xapp_enums + dbus_headers,
     include_directories: [top_inc],
     version: meson.project_version(),
     soversion: '1',
     dependencies: libdeps,
-    c_args: ['-Wno-declaration-after-statement'],
+    c_args: ['-Wno-declaration-after-statement', '-DG_LOG_DOMAIN="XApp"'],
     link_args: [ '-Wl,-Bsymbolic', '-Wl,-z,relro', '-Wl,-z,now', '-lm'],
     install: true
 )
@@ -59,13 +88,13 @@ libxapp_dep = declare_dependency(
     link_with: libxapp,
     include_directories: top_inc,
     dependencies: libdeps,
-    sources: [ xapp_headers ]
+    sources: [ xapp_headers, dbus_headers ]
 )
 
 gir = gnome.generate_gir(libxapp,
     namespace: 'XApp',
     nsversion: '1.0',
-    sources: xapp_headers + xapp_sources,
+    sources: xapp_headers + xapp_sources + dbus_headers,
     identifier_prefix: 'XApp',
     symbol_prefix: 'xapp_',
     includes: ['GObject-2.0', 'Gtk-3.0'],

--- a/libxapp/org.x.StatusIcon.xml
+++ b/libxapp/org.x.StatusIcon.xml
@@ -1,0 +1,26 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+                      "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<!-- GDBus 2.48.1 -->
+<node>
+  <interface name='org.x.StatusIcon'>
+    <method name='ButtonPress'>
+        <arg name='x' direction='in' type='i'/>
+        <arg name='y' direction='in' type='i'/>
+        <arg name='button' direction='in' type='u'/>
+        <arg name='time' direction='in' type='u'/>
+        <arg name='panel_position' direction='in' type='i'/>
+    </method>
+    <method name='ButtonRelease'>
+        <arg name='x' direction='in' type='i'/>
+        <arg name='y' direction='in' type='i'/>
+        <arg name='button' direction='in' type='u'/>
+        <arg name='time' direction='in' type='u'/>
+        <arg name='panel_position' direction='in' type='i'/>
+    </method>
+    <property type='s' name='Name' access='read'/>
+    <property type='s' name='IconName' access='read'/>
+    <property type='s' name='TooltipText' access='read'/>
+    <property type='s' name='Label' access='read'/>
+    <property type='b' name='Visible' access='read'/>
+  </interface>
+</node>

--- a/libxapp/xapp-status-icon-monitor.c
+++ b/libxapp/xapp-status-icon-monitor.c
@@ -1,0 +1,530 @@
+
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <gdk/gdkx.h>
+#include <gtk/gtk.h>
+
+#include <glib/gi18n-lib.h>
+
+#include "xapp-status-icon.h"
+#include "xapp-status-icon-monitor.h"
+#include "xapp-statusicon-interface.h"
+
+#define MONITOR_PATH "/org/x/StatusIconMonitor"
+#define MONITOR_NAME "org.x.StatusIconMonitor"
+
+#define STATUS_ICON_MATCH "org.x.StatusIcon."
+
+enum
+{
+    ICON_ADDED,
+    ICON_REMOVED,
+    LAST_SIGNAL
+};
+
+static guint signals[LAST_SIGNAL] = {0, };
+
+/**
+ * SECTION:xapp-status-icon-monitor
+ * @Short_description: Looks for XAppStatusIcons on DBUS and communicates
+ * info to an applet to represent the icons.
+ * @Title: XAppStatusIconMonitor
+ *
+ * The XAppStatusIconMonitor is intended to be utilized by some status applet
+ * to display info about an app.
+ *
+ * The simplest way to use is to make a new instance of this monitor, and connect
+ * to the #XAppStatusIconMonitor::icon-added and #XAppStatusIconMonitor::icon-removed signals.
+ * The received object for both of these signals is an #XAppStatusIconInterfaceProxy.
+ * It represents an application's #XAppStatusIcon, and has properties available for
+ * describing the icon name, tooltip, label and visibility.
+ *
+ * The proxy also provides methods to handle clicks, which can be called by the applet,
+ * to request that the app display its menu.
+ */
+typedef struct
+{
+    GDBusConnection *connection;
+
+    GHashTable *icons;
+    gchar *name;
+
+    guint owner_id;
+    guint listener_id;
+
+} XAppStatusIconMonitorPrivate;
+
+struct _XAppStatusIconMonitor
+{
+    GObject parent_instance;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (XAppStatusIconMonitor, xapp_status_icon_monitor, G_TYPE_OBJECT)
+
+static void remove_icon (XAppStatusIconMonitor *self, const gchar *name);
+
+static void
+on_proxy_name_owner_changed (GObject    *object,
+                             GParamSpec *pspec,
+                             gpointer    user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    gchar *name_owner = NULL;
+    gchar *proxy_name = NULL;
+
+    g_object_get (object,
+                  "g-name-owner", &name_owner,
+                  "g-name", &proxy_name,
+                  NULL);
+
+    g_debug("XAppStatusIconMonitor: proxy name owner changed - name owner '%s' is now '%s')", proxy_name, name_owner);
+
+    if (name_owner == NULL)
+    {
+        remove_icon (self, proxy_name);
+    }
+
+    g_free (name_owner);
+    g_free (proxy_name);
+}
+
+static void
+remove_icon (XAppStatusIconMonitor *self,
+             const gchar           *name)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+    XAppStatusIconInterface *proxy;
+
+    proxy = g_hash_table_lookup (priv->icons, name);
+
+    if (proxy)
+    {
+        g_object_ref (proxy);
+
+        g_signal_handlers_disconnect_by_func (proxy,
+                                              on_proxy_name_owner_changed,
+                                              self);
+
+        if (g_hash_table_remove (priv->icons, name))
+        {
+            g_debug("XAppStatusIconMonitor: removing icon: '%s'", name);
+
+            g_signal_emit (self, signals[ICON_REMOVED], 0, proxy);
+        }
+        else
+        {
+            g_assert_not_reached ();
+        }
+
+        g_object_unref (proxy);
+    }
+}
+
+static void
+new_status_icon_proxy_complete (GObject      *object,
+                                GAsyncResult *res,
+                                gpointer      user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+    XAppStatusIconInterface *proxy;
+    GError *error;
+    gchar *g_name;
+
+    error = NULL;
+
+    proxy = xapp_status_icon_interface_proxy_new_finish (res,
+                                                         &error);
+
+    if (error)
+    {
+        g_warning ("Couldn't add status icon: %s", error->message);
+        g_error_free (error);
+        return;
+    }
+
+    g_signal_connect_object (proxy,
+                             "notify::g-name-owner",
+                             G_CALLBACK (on_proxy_name_owner_changed),
+                             self,
+                             0);
+
+    g_object_get (proxy, "g-name", &g_name, NULL);
+
+    g_hash_table_insert (priv->icons,
+                         g_name,
+                         proxy);
+
+    g_signal_emit (self, signals[ICON_ADDED], 0, proxy);
+}
+
+static void
+add_icon (XAppStatusIconMonitor *self,
+          const gchar           *name)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    g_debug("XAppStatusIconMonitor: adding icon: '%s'", name);
+
+    xapp_status_icon_interface_proxy_new (priv->connection,
+                                          G_DBUS_PROXY_FLAGS_NONE,
+                                          name,
+                                          "/org/x/StatusIcon",
+                                          NULL,
+                                          new_status_icon_proxy_complete,
+                                          self);
+}
+
+static void
+on_list_names_completed (GObject      *source,
+                         GAsyncResult *res,
+                         gpointer      user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+    GVariant *result;
+    GVariantIter *iter;
+    gchar *str;
+    GError *error;
+
+    error = NULL;
+
+    result = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source),
+                                            res,
+                                            &error);
+
+    if (error != NULL)
+    {
+      g_critical ("XAppStatusIconMonitor: attempt to ListNames failed: %s\n", error->message);
+      g_error_free (error);
+      return;
+    }
+
+    g_variant_get (result, "(as)", &iter);
+
+    while (g_variant_iter_loop (iter, "s", &str))
+    {
+        /* the '.' at the end so we don't catch ourselves in this */
+        if (g_str_has_prefix (str, STATUS_ICON_MATCH))
+        {
+            g_debug ("XAppStatusIconMonitor: found icon: %s", str);
+            add_icon (self, str);
+        }
+    }
+
+    g_variant_iter_free (iter);
+    g_variant_unref (result);
+}
+
+static void
+find_and_add_icons (XAppStatusIconMonitor *self)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+
+    g_debug("XAppStatusIconMonitor: looking for status icons on the bus");
+
+    /* If there are no monitors (applets) already running when this is set up,
+     * this won't find anything.  The XAppStatusIcons will be in fallback mode,
+     * and will only attempt to switch back after seeing this monitor appear
+     * on the bus, which means they'll show up via our NameOwnerChanged handler.
+     * Basically, this will never find anything if we're the first monitor to appear
+     * on the bus.
+     */
+
+    g_dbus_connection_call (priv->connection,
+                            "org.freedesktop.DBus",
+                            "/org/freedesktop/DBus",
+                            "org.freedesktop.DBus",
+                            "ListNames",
+                            NULL,
+                            G_VARIANT_TYPE ("(as)"),
+                            G_DBUS_CALL_FLAGS_NONE,
+                            3000, /* 3 secs */
+                            NULL,
+                            on_list_names_completed,
+                            self);
+}
+
+static void
+status_icon_name_appeared (XAppStatusIconMonitor *self,
+                           const gchar           *name,
+                           const gchar           *owner)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    if (!g_str_has_prefix (name, STATUS_ICON_MATCH))
+    {
+        return;
+    }
+
+    if (g_hash_table_contains (priv->icons, name))
+    {
+        return;
+    }
+
+    g_debug ("XAppStatusIconMonitor: new icon appeared: %s", name);
+
+    add_icon (self, name);
+}
+
+static void
+status_icon_name_vanished (XAppStatusIconMonitor *self,
+                           const gchar           *name)
+{
+    if (!g_str_has_prefix (name, STATUS_ICON_MATCH))
+    {
+        return;
+    }
+
+    g_debug ("XAppStatusIconMonitor: icon presence vanished: %s", name);
+
+    remove_icon (self, name);
+}
+
+static void
+name_owner_changed (GDBusConnection *connection,
+                    const gchar     *sender_name,
+                    const gchar     *object_path,
+                    const gchar     *interface_name,
+                    const gchar     *signal_name,
+                    GVariant        *parameters,
+                    gpointer         user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+
+    const gchar *name;
+    const gchar *old_owner;
+    const gchar *new_owner;
+
+    g_debug("XAppStatusIconMonitor: NameOwnerChanged signal received: %s)", sender_name);
+
+    g_variant_get (parameters, "(&s&s&s)", &name, &old_owner, &new_owner);
+
+    if (old_owner[0] != '\0')
+    {
+        status_icon_name_vanished (self, name);
+    }
+
+    if (new_owner[0] != '\0')
+    {
+        status_icon_name_appeared (self, name, new_owner);
+    }
+}
+
+
+static void
+add_name_listener (XAppStatusIconMonitor *self)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    g_debug ("XAppStatusIconMonitor: Adding NameOwnerChanged listener for status icons");
+
+    priv->listener_id = g_dbus_connection_signal_subscribe (priv->connection,
+                                                            "org.freedesktop.DBus",
+                                                            "org.freedesktop.DBus",
+                                                            "NameOwnerChanged",
+                                                            "/org/freedesktop/DBus",
+                                                            "org.x.StatusIcon",
+                                                            G_DBUS_SIGNAL_FLAGS_MATCH_ARG0_NAMESPACE,
+                                                            name_owner_changed,
+                                                            self,
+                                                            NULL);
+}
+
+static void
+on_name_lost (GDBusConnection *connection,
+              const gchar     *name,
+              gpointer         user_data)
+{
+    if (connection == NULL)
+    {
+        g_warning ("error acquiring session bus");
+    }
+}
+
+static void
+on_name_acquired (GDBusConnection *connection,
+                  const gchar     *name,
+                  gpointer         user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+
+    g_debug ("XAppStatusIconMonitor: name acquired on dbus");
+
+    add_name_listener (self);
+    find_and_add_icons (self);
+}
+
+static void
+on_bus_acquired (GDBusConnection *connection,
+                 const gchar     *name,
+                 gpointer         user_data)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (user_data);
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    g_debug ("XAppStatusIconMonitor: session bus connection acquired");
+
+    priv->connection = connection;
+}
+
+static void
+connect_to_bus (XAppStatusIconMonitor *self)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    static gint unique_id = 0;
+
+    char *owner_name = g_strdup_printf("%s.PID-%d-%d", MONITOR_NAME, getpid (), unique_id);
+
+    unique_id++;
+
+    g_debug ("XAppStatusIconMonitor: Attempting to acquire presence on dbus as %s", owner_name);
+
+    priv->owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
+                                     owner_name,
+                                     G_DBUS_CONNECTION_FLAGS_NONE,
+                                     on_bus_acquired,
+                                     on_name_acquired,
+                                     on_name_lost,
+                                     self,
+                                     NULL);
+
+    g_free(owner_name);
+}
+
+static void
+xapp_status_icon_monitor_init (XAppStatusIconMonitor *self)
+{
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    priv->name = g_strdup_printf("%s", g_get_application_name());
+
+    priv->icons = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                         g_free, g_object_unref);
+
+    connect_to_bus (self);
+}
+
+static void
+xapp_status_icon_monitor_dispose (GObject *object)
+{
+    XAppStatusIconMonitor *self = XAPP_STATUS_ICON_MONITOR (object);
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (self);
+
+    g_debug ("XAppStatusIconMonitor dispose (%p)", object);
+
+    if (priv->connection != NULL)
+    {
+        if (priv->listener_id > 0)
+        {
+            g_dbus_connection_signal_unsubscribe (priv->connection, priv->listener_id);
+        }
+
+        if (priv->owner_id > 0)
+        {
+            g_bus_unown_name(priv->owner_id);
+        }
+
+        g_clear_object (&priv->connection);
+    }
+
+    g_free (priv->name);
+    g_clear_pointer (&priv->icons, g_hash_table_unref);
+
+    G_OBJECT_CLASS (xapp_status_icon_monitor_parent_class)->dispose (object);
+}
+
+static void
+xapp_status_icon_monitor_finalize (GObject *object)
+{
+    g_debug ("XAppStatusIconMonitor finalize (%p)", object);
+
+    G_OBJECT_CLASS (xapp_status_icon_monitor_parent_class)->dispose (object);
+}
+
+static void
+xapp_status_icon_monitor_class_init (XAppStatusIconMonitorClass *klass)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+
+    gobject_class->dispose = xapp_status_icon_monitor_dispose;
+    gobject_class->finalize = xapp_status_icon_monitor_finalize;
+
+  /**
+   * XAppStatusIconMonitor::icon-added:
+   * @monitor: the #XAppStatusIconMonitor
+   * @proxy: the interface proxy for the #XAppStatusIcon that has been added.
+   *
+   * This signal is emitted by the monitor when it has discovered a new
+   * #XAppStatusIcon on the bus.
+   */
+    signals[ICON_ADDED] =
+        g_signal_new ("icon-added",
+                      XAPP_TYPE_STATUS_ICON_MONITOR,
+                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE, 1, XAPP_TYPE_STATUS_ICON_INTERFACE_PROXY);
+
+  /**
+   * XAppStatusIconMonitor::icon-removed:
+   * @monitor: the #XAppStatusIconMonitor
+   * @proxy: the #XAppStatusIcon proxy that has been removed.
+   *
+   * This signal is emitted by the monitor when an #XAppStatusIcon has disappeared
+   * from the bus.
+   */
+    signals[ICON_REMOVED] =
+        g_signal_new ("icon-removed",
+                      XAPP_TYPE_STATUS_ICON_MONITOR,
+                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE, 1, XAPP_TYPE_STATUS_ICON_INTERFACE_PROXY);
+}
+
+/**
+ * xapp_status_icon_monitor_list_icons:
+ * @monitor: a #XAppStatusIconMonitor
+ *
+ * List known icon proxies.
+ *
+ * Returns: (element-type XAppStatusIconMonitor) (transfer container): a #GList of icons
+ *
+ * Since: 1.6
+ */
+GList *
+xapp_status_icon_monitor_list_icons (XAppStatusIconMonitor *monitor)
+{
+    g_return_val_if_fail (XAPP_IS_STATUS_ICON_MONITOR (monitor), NULL);
+
+    XAppStatusIconMonitorPrivate *priv = xapp_status_icon_monitor_get_instance_private (monitor);
+
+    return g_hash_table_get_values (priv->icons);
+}
+
+/**
+ * xapp_status_icon_monitor_new:
+ *
+ * Creates a new monitor.
+ *
+ * Returns: (transfer full): a new #XAppStatusIconMonitor. Use g_object_unref when finished.
+ *
+ * Since: 1.6
+ */
+XAppStatusIconMonitor *
+xapp_status_icon_monitor_new (void)
+{
+    return g_object_new (XAPP_TYPE_STATUS_ICON_MONITOR, NULL);
+}
+

--- a/libxapp/xapp-status-icon-monitor.h
+++ b/libxapp/xapp-status-icon-monitor.h
@@ -1,0 +1,20 @@
+#ifndef __XAPP_STATUS_ICON_MONITOR_H__
+#define __XAPP_STATUS_ICON_MONITOR_H__
+
+#include <stdio.h>
+#include <gtk/gtk.h>
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define XAPP_TYPE_STATUS_ICON_MONITOR   (xapp_status_icon_monitor_get_type ())
+
+G_DECLARE_FINAL_TYPE (XAppStatusIconMonitor, xapp_status_icon_monitor, XAPP, STATUS_ICON_MONITOR, GObject)
+
+XAppStatusIconMonitor *xapp_status_icon_monitor_new        (void);
+GList                 *xapp_status_icon_monitor_list_icons (XAppStatusIconMonitor *monitor);
+
+G_END_DECLS
+
+#endif  /* __XAPP_STATUS_ICON_MONITOR_H__ */

--- a/libxapp/xapp-status-icon.c
+++ b/libxapp/xapp-status-icon.c
@@ -14,39 +14,24 @@
 #include <glib/gi18n-lib.h>
 
 #include "xapp-status-icon.h"
+#include "xapp-statusicon-interface.h"
 
-static const gchar * DBUS_PATH = "/org/x/StatusIcon";
-static const gchar * DBUS_NAME = "org.x.StatusIcon";
+#define FDO_DBUS_NAME "org.freedesktop.DBus"
+#define FDO_DBUS_PATH "/org/freedesktop/DBus"
 
-static const gchar introspection_xml[] =
-    "<node>"
-    "    <interface name='org.x.StatusIcon'>"
-    "    <method name='ButtonPress'>"
-    "        <arg name='x' direction='in' type='i'/>"
-    "        <arg name='y' direction='in' type='i'/>"
-    "        <arg name='button' direction='in' type='i'/>"
-    "        <arg name='time' direction='in' type='i'/>"
-    "        <arg name='panel_position' direction='in' type='i'/>"
-    "    </method>"
-    "    <method name='ButtonRelease'>"
-    "        <arg name='x' direction='in' type='i'/>"
-    "        <arg name='y' direction='in' type='i'/>"
-    "        <arg name='button' direction='in' type='i'/>"
-    "        <arg name='time' direction='in' type='i'/>"
-    "        <arg name='panel_position' direction='in' type='i'/>"
-    "    </method>"
-    "    <property type='s' name='Name' access='read'/>"
-    "    <property type='s' name='IconName' access='read'/>"
-    "    <property type='s' name='TooltipText' access='read'/>"
-    "    <property type='s' name='Label' access='read'/>"
-    "    <property type='b' name='Visible' access='read'/>"
-    "    </interface>"
-    "</node>";
+#define ICON_PATH "/org/x/StatusIcon"
+#define ICON_NAME "org.x.StatusIcon"
+
+#define STATUS_ICON_MONITOR_MATCH "org.x.StatusIconMonitor"
+
+#define MAX_NAME_FAILS 3
 
 enum
 {
     BUTTON_PRESS,
     BUTTON_RELEASE,
+    ACTIVATE,
+    POPUP_MENU,
     LAST_SIGNAL
 };
 
@@ -66,214 +51,562 @@ static guint signals[LAST_SIGNAL] = {0, };
  */
 struct _XAppStatusIconPrivate
 {
+    XAppStatusIconInterface *skeleton;
+    GDBusConnection *connection;
+
+    GCancellable *cancellable;
+
+    GtkStatusIcon *gtk_status_icon;
+    GtkWidget *menu;
+
     gchar *name;
     gchar *icon_name;
     gchar *tooltip_text;
     gchar *label;
     gboolean visible;
-    GDBusConnection *connection;
+
     guint owner_id;
-    guint registration_id;
-    GtkStatusIcon *gtk_status_icon;
+    guint listener_id;
+
+    gint fail_counter;
 };
 
 G_DEFINE_TYPE (XAppStatusIcon, xapp_status_icon, G_TYPE_OBJECT);
 
-void
-emit_changed_properties_signal (XAppStatusIcon *self)
-{
-    GVariantBuilder *builder;
-    GError *local_error;
+static void refresh_icon        (XAppStatusIcon *self);
+static void use_gtk_status_icon (XAppStatusIcon *self);
+static void tear_down_dbus      (XAppStatusIcon *self);
 
-    if (self->priv->connection)
+static void
+cancellable_init (XAppStatusIcon *self)
+{
+    if (self->priv->cancellable == NULL)
     {
-        local_error = NULL;
-        builder = g_variant_builder_new (G_VARIANT_TYPE_ARRAY);
-        if (self->priv->name)
-        {
-            g_variant_builder_add (builder, "{sv}", "Name", g_variant_new_string (self->priv->name));
-        }
-        if (self->priv->icon_name)
-        {
-            g_variant_builder_add (builder, "{sv}", "IconName", g_variant_new_string (self->priv->icon_name));
-        }
-        if (self->priv->tooltip_text)
-        {
-            g_variant_builder_add (builder, "{sv}", "TooltipText", g_variant_new_string (self->priv->tooltip_text));
-        }
-        if (self->priv->label)
-        {
-            g_variant_builder_add (builder, "{sv}", "Label", g_variant_new_string (self->priv->label));
-        }
-        if (self->priv->visible)
-        {
-            g_variant_builder_add (builder, "{sv}", "Visible", g_variant_new_boolean (self->priv->visible));
-        }
-        g_dbus_connection_emit_signal (self->priv->connection,
-                                       NULL,
-                                       DBUS_PATH,
-                                       "org.freedesktop.DBus.Properties",
-                                       "PropertiesChanged",
-                                       g_variant_new ("(sa{sv}as)", DBUS_NAME, builder, NULL),
-                                       &local_error);
+        self->priv->cancellable = g_cancellable_new ();
     }
 }
 
-void
-handle_method_call (GDBusConnection       *connection,
-                    const gchar           *sender,
-                    const gchar           *object_path,
-                    const gchar           *interface_name,
-                    const gchar           *method_name,
-                    GVariant              *parameters,
-                    GDBusMethodInvocation *invocation,
-                    gpointer               user_data)
+static const gchar *
+panel_position_to_str (GtkPositionType type)
 {
-    int x, y, time, button, position;
-    XAppStatusIcon *icon = user_data;
-
-    if (g_strcmp0 (method_name, "ButtonPress") == 0)
+    switch (type)
     {
-        g_variant_get (parameters, "(iiiii)", &x, &y, &button, &time, &position);
-        g_dbus_method_invocation_return_value (invocation, NULL);
-        g_signal_emit (icon, signals[BUTTON_PRESS], 0, x, y, button, time, position);
-    }
-    else if (g_strcmp0 (method_name, "ButtonRelease") == 0)
-    {
-        g_variant_get (parameters, "(iiiii)", &x, &y, &button, &time, &position);
-        g_dbus_method_invocation_return_value (invocation, NULL);
-        g_signal_emit (icon, signals[BUTTON_RELEASE], 0, x, y, button, time, position);
+        case GTK_POS_LEFT:
+            return "Left";
+        case GTK_POS_RIGHT:
+            return "Right";
+        case GTK_POS_TOP:
+            return "Top";
+        case GTK_POS_BOTTOM:
+        default:
+            return "Bottom";
     }
 }
-
-GVariant *
-get_property (GDBusConnection  *connection,
-              const gchar      *sender,
-              const gchar      *object_path,
-              const gchar      *interface_name,
-              const gchar      *property_name,
-              GError          **error,
-              gpointer          user_data)
-{
-    GVariant *ret;
-    XAppStatusIcon *icon = user_data;
-    ret = NULL;
-
-    if (icon->priv->name && g_strcmp0 (property_name, "Name") == 0)
-    {
-        ret = g_variant_new_string (icon->priv->name);
-    }
-    else if (icon->priv->icon_name && g_strcmp0 (property_name, "IconName") == 0)
-    {
-        ret = g_variant_new_string (icon->priv->icon_name);
-    }
-    else if (icon->priv->tooltip_text && g_strcmp0 (property_name, "TooltipText") == 0)
-    {
-        ret = g_variant_new_string (icon->priv->tooltip_text);
-    }
-    else if (icon->priv->label && g_strcmp0 (property_name, "Label") == 0)
-    {
-        ret = g_variant_new_string (icon->priv->label);
-    }
-    else if (g_strcmp0 (property_name, "Visible") == 0)
-    {
-        ret = g_variant_new_boolean (icon->priv->visible);
-    }
-
-    return ret;
-}
-
-static const GDBusInterfaceVTable interface_vtable =
-{
-    handle_method_call,
-    get_property,
-    NULL
-};
-
-void
-on_bus_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data)
-{
-    XAppStatusIcon *icon = user_data;
-    icon->priv->connection = connection;
-    GDBusNodeInfo *introspection_data = g_dbus_node_info_new_for_xml (introspection_xml, NULL);
-    icon->priv->registration_id = g_dbus_connection_register_object (connection,
-                     DBUS_PATH,
-                     introspection_data->interfaces[0],
-                     &interface_vtable,
-                     icon,  /* user_data */
-                     NULL,  /* user_data_free_func */
-                     NULL); /* GError** */
-}
-
-void on_name_acquired (GDBusConnection *connection, const gchar *name, gpointer user_data) {}
-void on_name_lost (GDBusConnection *connection, const gchar *name, gpointer user_data) {}
 
 static gboolean
-check_at_least_one_status_applet_is_running ()
+handle_click_method (XAppStatusIconInterface *skeleton,
+                     GDBusMethodInvocation   *invocation,
+                     gint                     x,
+                     gint                     y,
+                     guint                    button,
+                     guint                    _time,
+                     gint                     panel_position,
+                     XAppStatusIcon          *icon)
 {
-    // Check that there is at least one applet on DBUS
-    GDBusConnection *connection;
-    GVariant *result;
-    GError *error;
-    GVariantIter *iter;
-    gchar *str;
-    gboolean found = FALSE;
+    const gchar *name = g_dbus_method_invocation_get_method_name (invocation);
 
-    error = NULL;
-    connection = g_bus_get_sync(G_BUS_TYPE_SESSION, NULL, &error);
-    if (connection == NULL)
+    if (g_strcmp0 (name, "ButtonPress") == 0)
     {
-        g_warning("Unable to connect to dbus: %s", error->message);
-        g_printerr ("Error: %s\n", error->message);
-        g_error_free (error);
-        return FALSE;
+        g_debug ("XAppStatusIcon: received ButtonPress from monitor %s: "
+                 "pos:%d,%d , button: %u , time: %u , orientation: %s",
+                 g_dbus_method_invocation_get_sender (invocation),
+                 x, y, button, _time, panel_position_to_str (panel_position));
+
+        g_signal_emit (icon, signals[BUTTON_PRESS], 0, x, y, button, _time, panel_position);
+
+        xapp_status_icon_interface_complete_button_press (skeleton,
+                                                          invocation);
+    }
+    else
+    if (g_strcmp0 (name, "ButtonRelease") == 0)
+    {
+        g_debug ("XAppStatusIcon: received ButtonRelease from monitor %s: "
+                 "pos:%d,%d , button: %u , time: %u , orientation: %s",
+                 g_dbus_method_invocation_get_sender (invocation),
+                 x, y, button, _time, panel_position_to_str (panel_position));
+
+        g_signal_emit (icon, signals[BUTTON_RELEASE], 0, x, y, button, _time, panel_position);
+
+        xapp_status_icon_interface_complete_button_release (skeleton,
+                                                            invocation);
     }
 
-    error = NULL;
-    result = g_dbus_connection_call_sync (connection,
-                                          "org.freedesktop.DBus",
-                                          "/org/freedesktop/DBus",
-                                          "org.freedesktop.DBus",
-                                          "ListNames",
-                                          NULL,
-                                          G_VARIANT_TYPE ("(as)"),
-                                          G_DBUS_CALL_FLAGS_NONE,
-                                          3000, /* 3 secs */
-                                          NULL,
-                                          &error);
-    if (result == NULL)
-    {
-      g_printerr (_("Error: %s\n"), error->message);
-      g_error_free (error);
-      return FALSE;
-    }
+    return TRUE;
+}
 
-    g_variant_get (result, "(as)", &iter);
-    while (g_variant_iter_loop (iter, "s", &str))
-    {
-        if (g_str_has_prefix (str, "org.x.StatusApplet"))
-        {
-            // printf("FOUND %s\n", str);
-            found = TRUE;
-        }
-    }
-    g_variant_iter_free (iter);
-    g_variant_unref (result);
-    return found;
+static void
+popup_gtk_status_icon_with_menu (XAppStatusIcon *icon,
+                                 GtkStatusIcon  *gtk_status_icon,
+                                 guint           button,
+                                 guint           activate_time)
+{
+    /* We have a menu widget we can pass to the gtk positioning function */
+    gtk_menu_popup (GTK_MENU (icon->priv->menu),
+                    NULL,
+                    NULL,
+                    gtk_status_icon_position_menu,
+                    gtk_status_icon,
+                    button,
+                    activate_time);
 }
 
 static void
 on_gtk_status_icon_activate (GtkStatusIcon *status_icon, gpointer user_data)
 {
     XAppStatusIcon *icon = user_data;
-    g_signal_emit (icon, signals[BUTTON_PRESS], 0, 0, 0, 1, 0, -1);
+
+    g_debug ("XAppStatusIcon: GtkStatusIcon activate");
+
+    if (g_object_get_data (G_OBJECT (icon), "app-indicator"))
+    {
+        g_debug ("XAppStatusIcon: GtkStatusIcon (app-indicator) left-click popup menu with menu provided");
+
+        popup_gtk_status_icon_with_menu (icon,
+                                         status_icon,
+                                         GDK_BUTTON_PRIMARY,
+                                         gtk_get_current_event_time ());
+    }
+    else
+    {
+        g_signal_emit (icon, signals[BUTTON_PRESS], 0, 0, 0, GDK_BUTTON_PRIMARY, gtk_get_current_event_time (), -1);
+    }
 }
 
 static void
 on_gtk_status_icon_popup_menu (GtkStatusIcon *status_icon, guint button, guint activate_time, gpointer user_data)
 {
     XAppStatusIcon *icon = user_data;
-    g_signal_emit (icon, signals[BUTTON_RELEASE], 0, 0, 0, button, activate_time, -1);
+
+    if (icon->priv->menu)
+    {
+        g_debug ("XAppStatusIcon: GtkStatusIcon popup menu with menu provided");
+
+        popup_gtk_status_icon_with_menu (icon,
+                                         status_icon,
+                                         button,
+                                         activate_time);
+    }
+    else
+    {
+        g_debug ("XAppStatusIcon: GtkStatusIcon popup menu with NO menu provided");
+
+        /* No menu provided, do our best to pass along good position info the app or appindicator 
+         * (if they're not using patched appindicator) */
+        GdkScreen *screen;
+        GdkRectangle irect;
+        GtkOrientation orientation;
+        gint final_x, final_y, final_o;
+
+        if (gtk_status_icon_get_geometry (status_icon,
+                                          &screen,
+                                          &irect,
+                                          &orientation))
+        {
+            GdkDisplay *display = gdk_screen_get_display (screen);
+            GdkMonitor *monitor;
+            GdkRectangle mrect;
+
+            monitor = gdk_display_get_monitor_at_point (display,
+                                                        irect.x + (irect.width / 2),
+                                                        irect.y + (irect.height / 2));
+
+            gdk_monitor_get_workarea (monitor, &mrect);
+
+            switch (orientation)
+            {
+                case GTK_ORIENTATION_HORIZONTAL:
+                    final_x = irect.x;
+
+                    if (irect.y + irect.height + 100 < mrect.y + mrect.height)
+                    {
+                        final_y = irect.y + irect.height;
+                        final_o = GTK_POS_TOP;
+                    }
+                    else
+                    {
+                        final_y = irect.y;
+                        final_o = GTK_POS_BOTTOM;
+                    }
+
+                    break;
+                case GTK_ORIENTATION_VERTICAL:
+                    final_y = irect.y;
+
+                    if (irect.x + irect.width + 100 < mrect.x + mrect.width)
+                    {
+                        final_x = irect.x + irect.width;
+                        final_o = GTK_POS_LEFT;
+                    }
+                    else
+                    {
+                        final_x = irect.x;
+                        final_o = GTK_POS_RIGHT;
+                    }
+            }
+
+            g_signal_emit (icon, signals[BUTTON_RELEASE], 0, final_x, final_y, button, activate_time, final_o);
+        }
+        else
+        {
+            g_signal_emit (icon, signals[BUTTON_RELEASE], 0, 0, 0, button, activate_time, -1);
+        }
+    }
+}
+
+static void
+name_owner_changed (GDBusConnection *connection,
+                    const gchar     *sender_name,
+                    const gchar     *object_path,
+                    const gchar     *interface_name,
+                    const gchar     *signal_name,
+                    GVariant        *parameters,
+                    gpointer         user_data)
+{
+    XAppStatusIcon *self = XAPP_STATUS_ICON (user_data);
+    g_debug("XAppStatusIcon: NameOwnerChanged signal received, refreshing icon");
+
+    refresh_icon (self);
+}
+
+static void
+add_name_listener (XAppStatusIcon *self)
+{
+    g_debug ("XAppStatusIcon: Adding NameOwnerChanged listener for status monitors");
+
+    self->priv->listener_id = g_dbus_connection_signal_subscribe (self->priv->connection,
+                                                                  FDO_DBUS_NAME,
+                                                                  FDO_DBUS_NAME,
+                                                                  "NameOwnerChanged",
+                                                                  FDO_DBUS_PATH,
+                                                                  STATUS_ICON_MONITOR_MATCH,
+                                                                  G_DBUS_SIGNAL_FLAGS_MATCH_ARG0_NAMESPACE,
+                                                                  name_owner_changed,
+                                                                  self,
+                                                                  NULL);
+}
+
+typedef struct
+{
+    const gchar  *signal_name;
+    gpointer      callback;
+} SkeletonSignal;
+
+static SkeletonSignal skeleton_signals[] = {
+    // signal name                                callback
+    { "handle-button-press",                      handle_click_method },
+    { "handle-button-release",                    handle_click_method }
+};
+
+static void
+on_name_lost (GDBusConnection *connection,
+              const gchar     *name,
+              gpointer         user_data)
+{
+    XAppStatusIcon *self = XAPP_STATUS_ICON (user_data);
+
+    g_warning ("XAppStatusIcon: lost or could not acquire presence on dbus.  Refreshing.");
+
+    self->priv->fail_counter++;
+
+    refresh_icon (self);
+}
+
+static void
+on_name_acquired (GDBusConnection *connection,
+                  const gchar     *name,
+                  gpointer         user_data)
+{
+    XAppStatusIcon *self = XAPP_STATUS_ICON (user_data);
+    XAppStatusIconPrivate *priv = self->priv;
+
+    g_debug ("XAppStatusIcon: name acquired on dbus, syncing icon properties");
+
+    priv->fail_counter = 0;
+
+    g_object_set (G_OBJECT (priv->skeleton),
+                  "name", priv->name,
+                  "label", priv->label,
+                  "icon-name", priv->icon_name,
+                  "tooltip-text", priv->tooltip_text,
+                  "visible", priv->visible,
+                  NULL);
+
+    g_dbus_interface_skeleton_flush (G_DBUS_INTERFACE_SKELETON (priv->skeleton));
+}
+
+static gboolean
+export_icon_interface (XAppStatusIcon *self)
+{
+    GError *error = NULL;
+    gint i;
+
+    if (self->priv->skeleton) {
+        return TRUE;
+    }
+
+    self->priv->skeleton = xapp_status_icon_interface_skeleton_new ();
+
+    g_debug ("XAppStatusIcon: exporting StatusIcon dbus interface");
+
+    g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (self->priv->skeleton),
+                                      self->priv->connection,
+                                      ICON_PATH,
+                                      &error);
+
+    if (error != NULL) {
+        g_critical ("XAppStatusIcon: could not export StatusIcon interface: %s", error->message);
+        g_error_free (error);
+
+        return FALSE;
+    }
+
+    for (i = 0; i < G_N_ELEMENTS (skeleton_signals); i++) {
+            SkeletonSignal sig = skeleton_signals[i];
+
+            g_signal_connect (self->priv->skeleton,
+                              sig.signal_name,
+                              G_CALLBACK (sig.callback),
+                              self);
+    }
+
+    return TRUE;
+}
+
+static void
+connect_with_status_applet (XAppStatusIcon *self)
+{
+    g_clear_object (&self->priv->gtk_status_icon);
+
+    char *owner_name = g_strdup_printf("%s.PID-%d", ICON_NAME, getpid());
+
+    g_debug ("XAppStatusIcon: Attempting to acquire presence on dbus as %s", owner_name);
+
+    self->priv->owner_id = g_bus_own_name_on_connection (self->priv->connection,
+                                                         owner_name,
+                                                         G_DBUS_CONNECTION_FLAGS_NONE,
+                                                         on_name_acquired,
+                                                         on_name_lost,
+                                                         self,
+                                                         NULL);
+
+    g_free(owner_name);
+}
+
+static void
+update_fallback_icon (XAppStatusIcon *self,
+                      const gchar    *icon_name)
+{
+    if (g_path_is_absolute (icon_name))
+    {
+        gtk_status_icon_set_from_file (self->priv->gtk_status_icon, icon_name);
+    }
+    else
+    {
+        gtk_status_icon_set_from_icon_name (self->priv->gtk_status_icon, icon_name);
+    }
+}
+
+static void
+use_gtk_status_icon (XAppStatusIcon *self)
+{
+    XAppStatusIconPrivate *priv = self->priv;
+
+    g_debug ("XAppStatusIcon: falling back to GtkStatusIcon");
+
+    tear_down_dbus (self);
+g_printerr ("??????\n");
+    self->priv->gtk_status_icon = gtk_status_icon_new ();
+
+    g_signal_connect (priv->gtk_status_icon, "activate", G_CALLBACK (on_gtk_status_icon_activate), self);
+    g_signal_connect (priv->gtk_status_icon, "popup-menu", G_CALLBACK (on_gtk_status_icon_popup_menu), self);
+
+    update_fallback_icon (self, priv->icon_name ? priv->icon_name : "");
+    gtk_status_icon_set_tooltip_text (self->priv->gtk_status_icon, priv->tooltip_text);
+}
+
+static void
+on_list_names_completed (GObject      *source,
+                         GAsyncResult *res,
+                         gpointer      user_data)
+{
+    XAppStatusIcon *self = XAPP_STATUS_ICON(user_data);
+    GVariant *result;
+    GVariantIter *iter;
+    gchar *str;
+    GError *error;
+    gboolean found;
+
+    error = NULL;
+
+    result = g_dbus_connection_call_finish (G_DBUS_CONNECTION (source),
+                                            res,
+                                            &error);
+
+    if (error != NULL)
+    {
+        if (!g_cancellable_is_cancelled (self->priv->cancellable))
+        {
+            g_critical ("XAppStatusIcon: attempt to ListNames failed: %s\n", error->message);
+        }
+        else
+        {
+            g_clear_object (&self->priv->cancellable);
+        }
+
+        g_error_free (error);
+
+        use_gtk_status_icon (self);
+
+        return;
+    }
+
+    g_variant_get (result, "(as)", &iter);
+
+    found = FALSE;
+
+    while (g_variant_iter_loop (iter, "s", &str))
+    {
+        if (g_str_has_prefix (str, STATUS_ICON_MONITOR_MATCH))
+        {
+            g_debug ("XAppStatusIcon: Discovered active status monitor (%s)", str);
+            found = TRUE;
+        }
+    }
+
+    g_variant_iter_free (iter);
+    g_variant_unref (result);
+
+    if (found && export_icon_interface (self))
+    {
+        if (self->priv->owner_id == 0)
+        {
+            g_clear_object (&self->priv->gtk_status_icon);
+
+            connect_with_status_applet (self);
+
+            return;
+        }
+    }
+    else
+    {
+        use_gtk_status_icon (self);
+    }
+}
+
+static void
+look_for_status_applet (XAppStatusIcon *self)
+{
+    // Check that there is at least one applet on DBUS
+    g_debug("XAppStatusIcon: Looking for status monitors");
+
+    cancellable_init (self);
+
+    g_dbus_connection_call (self->priv->connection,
+                            FDO_DBUS_NAME,
+                            FDO_DBUS_PATH,
+                            FDO_DBUS_NAME,
+                            "ListNames",
+                            NULL,
+                            G_VARIANT_TYPE ("(as)"),
+                            G_DBUS_CALL_FLAGS_NONE,
+                            3000, /* 3 secs */
+                            self->priv->cancellable,
+                            on_list_names_completed,
+                            self);
+}
+
+static void
+complete_icon_setup (XAppStatusIcon *self)
+{
+    if (self->priv->listener_id == 0)
+        {
+            add_name_listener (self);
+        }
+
+    /* There is a potential loop in the g_bus_own_name sequence -
+     * if we fail to acquire a name, we refresh again and potentially
+     * fail again.  If we fail more than MAX_NAME_FAILS, then quit trying
+     * and just use the fallback icon   It's pretty unlikely for*/
+    if (self->priv->fail_counter == MAX_NAME_FAILS)
+    {
+        use_gtk_status_icon (self);
+        return;
+    }
+
+    look_for_status_applet (self);
+}
+
+static void
+on_session_bus_connected (GObject      *source,
+                          GAsyncResult *res,
+                          gpointer      user_data)
+{
+    XAppStatusIcon *self = XAPP_STATUS_ICON (user_data);
+    GError *error;
+
+    error = NULL;
+
+    self->priv->connection = g_bus_get_finish (res, &error);
+
+    if (error != NULL)
+    {
+        if (!g_cancellable_is_cancelled (self->priv->cancellable))
+        {
+            g_critical ("XAppStatusIcon: Unable to acquire session bus: %s", error->message);
+        }
+        else
+        {
+            g_clear_object (&self->priv->cancellable);
+        }
+
+        g_error_free (error);
+
+        /* If we never get a connection, we use the Gtk icon exclusively, and will never
+         * re-try.  FIXME? this is unlikely to happen, so I don't see the point in trying
+         * later, as there are probably bigger problems in this case. */
+        use_gtk_status_icon (self);
+
+        return;
+    }
+
+    if (self->priv->connection)
+    {
+        complete_icon_setup (self);
+
+        return;
+    }
+
+    use_gtk_status_icon (self);
+}
+
+static void
+refresh_icon (XAppStatusIcon *self)
+{
+    if (!self->priv->connection)
+    {
+        g_debug ("XAppStatusIcon: Trying to acquire session bus connection");
+
+        self->priv->cancellable = g_cancellable_new ();
+
+        g_bus_get (G_BUS_TYPE_SESSION,
+                   self->priv->cancellable,
+                   on_session_bus_connected,
+                   self);
+    }
+    else
+    {
+        complete_icon_setup (self);
+    }
 }
 
 static void
@@ -281,63 +614,49 @@ xapp_status_icon_init (XAppStatusIcon *self)
 {
     self->priv = G_TYPE_INSTANCE_GET_PRIVATE (self, XAPP_TYPE_STATUS_ICON, XAppStatusIconPrivate);
     self->priv->name = g_strdup_printf("%s", g_get_application_name());
-    self->priv->icon_name = NULL;
-    self->priv->tooltip_text = NULL;
-    self->priv->label = NULL;
+
+    // Default to visible (the same behavior as GtkStatusIcon)
     self->priv->visible = TRUE;
-    self->priv->connection = NULL;
-    self->priv->owner_id = 0;
-    self->priv->registration_id = 0;
-    self->priv->gtk_status_icon = NULL;
 
-    // Check for an applet, if none..  fallback to delegating calls to a Gtk.StatusIcon
-    if (!check_at_least_one_status_applet_is_running())
-    {
-        self->priv->gtk_status_icon = gtk_status_icon_new ();
-        g_signal_connect (self->priv->gtk_status_icon, "activate", G_CALLBACK (on_gtk_status_icon_activate), self);
-        g_signal_connect (self->priv->gtk_status_icon, "popup-menu", G_CALLBACK (on_gtk_status_icon_popup_menu), self);
-    }
-    else
-    {
-        char *owner_name = g_strdup_printf("%s.PID-%d", DBUS_NAME, getpid());
-        self->priv->owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
-                    owner_name,
-                    G_DBUS_CONNECTION_FLAGS_NONE,
-                    on_bus_acquired,
-                    on_name_acquired,
-                    on_name_lost,
-                    self,
-                    NULL);
-
-        g_free(owner_name);
-    }
-
-    signals[BUTTON_PRESS] =
-        g_signal_new ("button-press-event",
-                      XAPP_TYPE_STATUS_ICON,
-                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                      0,
-                      NULL, NULL, NULL,
-                      G_TYPE_NONE, 5, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT);
-
-    signals[BUTTON_RELEASE] =
-        g_signal_new ("button-release-event",
-                      XAPP_TYPE_STATUS_ICON,
-                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
-                      0,
-                      NULL, NULL, NULL,
-                      G_TYPE_NONE, 5, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT, G_TYPE_INT);
+    refresh_icon (self);
 }
 
 static void
-xapp_status_icon_finalize (GObject *object)
+tear_down_dbus (XAppStatusIcon *self)
+{
+    g_return_if_fail (XAPP_IS_STATUS_ICON (self));
+
+    if (self->priv->owner_id > 0)
+    {
+        g_debug ("XAppStatusIcon: removing dbus presence (%p)", self);
+
+        g_bus_unown_name(self->priv->owner_id);
+        self->priv->owner_id = 0;
+    }
+
+    if (self->priv->skeleton)
+    {
+        g_debug ("XAppStatusIcon: removing dbus interface (%p)", self);
+
+        g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (self->priv->skeleton));
+        g_object_unref (self->priv->skeleton);
+        self->priv->skeleton = NULL;
+    }
+}
+
+static void
+xapp_status_icon_dispose (GObject *object)
 {
     XAppStatusIcon *self = XAPP_STATUS_ICON (object);
+
+    g_debug ("XAppStatusIcon dispose (%p)", object);
 
     g_free (self->priv->name);
     g_free (self->priv->icon_name);
     g_free (self->priv->tooltip_text);
     g_free (self->priv->label);
+
+    g_clear_pointer (&self->priv->cancellable, g_cancellable_cancel);
 
     if (self->priv->gtk_status_icon != NULL)
     {
@@ -346,15 +665,24 @@ xapp_status_icon_finalize (GObject *object)
         g_object_unref (self->priv->gtk_status_icon);
     }
 
-    if (self->priv->connection != NULL && self->priv->registration_id > 0)
+    tear_down_dbus (self);
+
+    if (self->priv->listener_id > 0)
     {
-        g_dbus_connection_unregister_object(self->priv->connection, self->priv->registration_id);
+        g_dbus_connection_signal_unsubscribe (self->priv->connection, self->priv->listener_id);
     }
 
-    if (self->priv->owner_id > 0)
-    {
-        g_bus_unown_name(self->priv->owner_id);
-    }
+    g_clear_object (&self->priv->connection);
+
+    G_OBJECT_CLASS (xapp_status_icon_parent_class)->dispose (object);
+}
+
+static void
+xapp_status_icon_finalize (GObject *object)
+{
+    g_debug ("XAppStatusIcon finalize (%p)", object);
+
+    g_clear_object (&XAPP_STATUS_ICON (object)->priv->cancellable);
 
     G_OBJECT_CLASS (xapp_status_icon_parent_class)->finalize (object);
 }
@@ -364,9 +692,86 @@ xapp_status_icon_class_init (XAppStatusIconClass *klass)
 {
     GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
+    gobject_class->dispose = xapp_status_icon_dispose;
     gobject_class->finalize = xapp_status_icon_finalize;
 
     g_type_class_add_private (gobject_class, sizeof (XAppStatusIconPrivate));
+
+  /**
+   * XAppStatusIcon::button-press-event:
+   * @icon: The #XAppStatusIcon
+   * @x: The absolute x position to use for menu positioning
+   * @y: The absolute y position to use for menu positioning
+   * @button: The button that was pressed
+   * @time: The time supplied by the event, or 0
+   * @panel_position: The #GtkPositionType to use for menu positioning
+   *
+   * Gets emitted when there is a button press received from an applet
+   */
+    signals[BUTTON_PRESS] =
+        g_signal_new ("button-press-event",
+                      XAPP_TYPE_STATUS_ICON,
+                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE, 5, G_TYPE_INT, G_TYPE_INT, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_INT);
+
+  /**
+   * XAppStatusIcon::button-release-event:
+   * @icon: The #XAppStatusIcon
+   * @x: The absolute x position to use for menu positioning
+   * @y: The absolute y position to use for menu positioning
+   * @button: The button that was released
+   * @time: The time supplied by the event, or 0
+   * @panel_position: The #GtkPositionType to use for menu positioning
+   *
+   * Gets emitted when there is a button release received from an applet
+   */
+    signals[BUTTON_RELEASE] =
+        g_signal_new ("button-release-event",
+                      XAPP_TYPE_STATUS_ICON,
+                      G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE, 5, G_TYPE_INT, G_TYPE_INT, G_TYPE_UINT, G_TYPE_UINT, G_TYPE_INT);
+
+  /**
+   * XAppStatusIcon::activate:
+   * @icon: The #XAppStatusIcon
+   *
+   * Gets emitted when the user activates the status icon. 
+   */
+    signals [ACTIVATE] =
+        g_signal_new ("activate",
+                      XAPP_TYPE_STATUS_ICON,
+                      G_SIGNAL_RUN_FIRST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE,
+                      0);
+
+  /**
+   * XAppStatusIcon::popup-menu:
+   * @icon: the #XAppStatusIcon
+   * @button: the button that was pressed, or 0 if the 
+   *   signal is not emitted in response to a button press event
+   * @activate_time: the timestamp of the event that
+   *   triggered the signal emission
+   *
+   * Gets emitted when the user brings up the context menu
+   * of the status icon.
+   *
+   */
+    signals [POPUP_MENU] =
+        g_signal_new ("popup-menu",
+                      XAPP_TYPE_STATUS_ICON,
+                      G_SIGNAL_RUN_FIRST | G_SIGNAL_ACTION,
+                      0,
+                      NULL, NULL, NULL,
+                      G_TYPE_NONE,
+                      2,
+                      G_TYPE_UINT,
+                      G_TYPE_UINT);
 }
 
 /**
@@ -382,9 +787,15 @@ void
 xapp_status_icon_set_name (XAppStatusIcon *icon, const gchar *name)
 {
     g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
-    g_free (icon->priv->name);
+    g_clear_pointer (&icon->priv->name, g_free);
     icon->priv->name = g_strdup (name);
-    emit_changed_properties_signal (icon);
+
+    g_debug ("XAppStatusIcon set_name: %s", name);
+
+    if (icon->priv->skeleton)
+    {
+        xapp_status_icon_interface_set_name (icon->priv->skeleton, name);
+    }
 
     if (icon->priv->gtk_status_icon != NULL)
     {
@@ -395,9 +806,9 @@ xapp_status_icon_set_name (XAppStatusIcon *icon, const gchar *name)
 /**
  * xapp_status_icon_set_icon_name:
  * @icon: a #XAppStatusIcon
- * @icon_name: an icon name
+ * @icon_name: An icon name or absolute path to an icon.
  *
- * Sets the icon name
+ * Sets the icon name or icon filename to use.
  *
  * Since: 1.6
  */
@@ -405,13 +816,19 @@ void
 xapp_status_icon_set_icon_name (XAppStatusIcon *icon, const gchar *icon_name)
 {
     g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
-    g_free (icon->priv->icon_name);
+    g_clear_pointer (&icon->priv->icon_name, g_free);
     icon->priv->icon_name = g_strdup (icon_name);
-    emit_changed_properties_signal (icon);
+
+    g_debug ("XAppStatusIcon set_icon_name: %s", icon_name);
+
+    if (icon->priv->skeleton)
+    {
+        xapp_status_icon_interface_set_icon_name (icon->priv->skeleton, icon_name);
+    }
 
     if (icon->priv->gtk_status_icon != NULL)
     {
-        gtk_status_icon_set_from_icon_name (icon->priv->gtk_status_icon, icon_name);
+        update_fallback_icon (icon, icon_name);
     }
 }
 
@@ -428,9 +845,15 @@ void
 xapp_status_icon_set_tooltip_text (XAppStatusIcon *icon, const gchar *tooltip_text)
 {
     g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
-    g_free (icon->priv->tooltip_text);
+    g_clear_pointer (&icon->priv->tooltip_text, g_free);
     icon->priv->tooltip_text = g_strdup (tooltip_text);
-    emit_changed_properties_signal (icon);
+
+    g_debug ("XAppStatusIcon set_tooltip_text: %s", tooltip_text);
+
+    if (icon->priv->skeleton)
+    {
+        xapp_status_icon_interface_set_tooltip_text (icon->priv->skeleton, tooltip_text);
+    }
 
     if (icon->priv->gtk_status_icon != NULL)
     {
@@ -451,9 +874,15 @@ void
 xapp_status_icon_set_label (XAppStatusIcon *icon, const gchar *label)
 {
     g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
-    g_free (icon->priv->label);
+    g_clear_pointer (&icon->priv->label, g_free);
     icon->priv->label = g_strdup (label);
-    emit_changed_properties_signal (icon);
+
+    g_debug ("XAppStatusIcon set_label: '%s'", label);
+
+    if (icon->priv->skeleton)
+    {
+        xapp_status_icon_interface_set_label (icon->priv->skeleton, label);
+    }
 }
 
 /**
@@ -470,10 +899,50 @@ xapp_status_icon_set_visible (XAppStatusIcon *icon, const gboolean visible)
 {
     g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
     icon->priv->visible = visible;
-    emit_changed_properties_signal (icon);
+
+    g_debug ("XAppStatusIcon set_visible: %s", visible ? "TRUE" : "FALSE");
+
+    if (icon->priv->skeleton)
+    {
+        xapp_status_icon_interface_set_visible (icon->priv->skeleton, visible);
+    }
 
     if (icon->priv->gtk_status_icon != NULL)
     {
         gtk_status_icon_set_visible (icon->priv->gtk_status_icon, visible);
     }
+}
+
+/**
+ * xapp_status_icon_set_menu:
+ * @icon: a #XAppStatusIcon
+ * @menu: A #GtkMenu to display when requested
+ *
+ * Sets a menu that will be used when requested.
+ *
+ * Since: 1.6
+ */
+void
+xapp_status_icon_set_menu (XAppStatusIcon *icon,
+                           GtkMenu        *menu)
+{
+    g_return_if_fail (XAPP_IS_STATUS_ICON (icon));
+
+    g_clear_object (&icon->priv->menu);
+    icon->priv->menu = GTK_WIDGET (g_object_ref (menu));
+}
+
+/**
+ * xapp_status_icon_new:
+ *
+ * Creates a new #XAppStatusIcon instance
+ *
+ * Returns: (transfer full): a new #XAppStatusIcon. Use g_object_unref when finished.
+ *
+ * Since: 1.6
+ */
+XAppStatusIcon *
+xapp_status_icon_new (void)
+{
+    return g_object_new (XAPP_TYPE_STATUS_ICON, NULL);
 }

--- a/libxapp/xapp-status-icon.h
+++ b/libxapp/xapp-status-icon.h
@@ -31,12 +31,17 @@ struct _XAppStatusIconClass
     GObjectClass parent_class;
 };
 
+typedef GObject (*XAppNewObjectFunc)       (void);
+
+
 GType xapp_status_icon_get_type         (void);
+XAppStatusIcon *xapp_status_icon_new    (void);
 void  xapp_status_icon_set_name         (XAppStatusIcon *icon, const gchar *name);
 void  xapp_status_icon_set_icon_name    (XAppStatusIcon *icon, const gchar *icon_name);
 void  xapp_status_icon_set_tooltip_text (XAppStatusIcon *icon, const gchar *tooltip_text);
 void  xapp_status_icon_set_label        (XAppStatusIcon *icon, const gchar *label);
 void  xapp_status_icon_set_visible      (XAppStatusIcon *icon, const gboolean visible);
+void  xapp_status_icon_set_menu         (XAppStatusIcon *icon, GtkMenu *menu);
 
 G_END_DECLS
 

--- a/test-scripts/xapp-status-applet
+++ b/test-scripts/xapp-status-applet
@@ -1,7 +1,8 @@
 #!/usr/bin/python3
 import gi
 gi.require_version('Gtk', '3.0')
-from gi.repository import Gio, GLib, GObject, Gtk
+gi.require_version('XApp', '1.0')
+from gi.repository import Gio, GLib, GObject, Gtk, XApp
 import os
 import sys
 
@@ -10,69 +11,65 @@ DBUS_PATH = "/org/x/StatusIcon"
 
 class StatusWidget(Gtk.Button):
 
-    def __init__(self, name, bus, dbus_proxy):
+    def __init__(self, icon):
         super(Gtk.Button, self).__init__()
 
-        self.name = name
-        self.bus = bus
-        self.dbus_proxy = dbus_proxy
-        self.properties_proxy = Gio.DBusProxy.new_sync(self.bus, Gio.DBusProxyFlags.NONE, None,
-                    name, DBUS_PATH, 'org.freedesktop.DBus.Properties', None)
-        self.proxy = Gio.DBusProxy.new_sync(self.bus, Gio.DBusProxyFlags.NONE, None,
-                    name, DBUS_PATH, DBUS_NAME, None)
+        self.proxy = icon
+        self.name = self.proxy.get_name()
 
-        owner = self.dbus_proxy.call_sync('GetNameOwner',
-                    GLib.Variant('(s)', (name,)),
-                    Gio.DBusCallFlags.NO_AUTO_START, 500, None)
-        self.owner_name = owner[0]
+        box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
 
-        properties = self.properties_proxy.GetAll('(s)', DBUS_NAME)
-
-        box = Gtk.Box()
         self.image = Gtk.Image()
         self.label = Gtk.Label()
-        box.add(self.image)
+        box.pack_start(self.image, False, False, 6)
         box.add(self.label)
         self.add(box)
 
-        self.update_widget(properties)
-        self.bus.signal_subscribe(sender=self.owner_name, interface_name="org.freedesktop.DBus.Properties", member="PropertiesChanged", object_path=None, arg0=None, flags=0, callback=self.on_properties_changed)
+        flags = GObject.BindingFlags.DEFAULT | GObject.BindingFlags.SYNC_CREATE
+
+        self.image.props.icon_size = Gtk.IconSize.DIALOG
+        self.set_icon(self.proxy.props.icon_name)
+        self.proxy.bind_property("label", self.label, "label", flags)
+        self.proxy.bind_property("tooltip-text", self, "tooltip-text", flags)
+        self.proxy.bind_property("visible", self, "visible", flags)
+
+        self.proxy.connect("notify::icon-name", self.on_icon_name_changed)
 
         self.connect("button-press-event", self.on_button_press)
         self.connect("button-release-event", self.on_button_release)
 
-    def on_properties_changed(self, connection, owner, path, interface, signal_name, properties):
-        self.update_widget(properties[1])
+    def on_icon_name_changed(self, proxy, gparamspec, data=None):
+        string = self.proxy.props.icon_name
 
-    def update_widget(self, properties):
-        if 'IconName' in properties:
-            self.image.set_from_icon_name(properties['IconName'], Gtk.IconSize.DIALOG)
-        if 'TooltipText' in properties:
-            self.set_tooltip_text(properties['TooltipText'])
-        if 'Label' in properties:
-            self.label.set_text(properties['Label'])
-        if 'Visible' in properties:
-            self.set_visible(properties['Visible'])
+        self.set_icon(string)
+
+    def set_icon(self, string):
+        if os.path.exists(string):
+            self.image.set_from_file(string)
+        else:
+            self.image.set_from_icon_name(string, Gtk.IconSize.DIALOG)
 
     def on_button_press(self, widget, event):
         # We're simulating a top panel here
-        x = widget.get_window().get_origin().x
-        y = widget.get_window().get_origin().y + widget.get_allocation().height
+        alloc = widget.get_allocation()
+        ignore, x, y = widget.get_window().get_origin()
+
+        x += alloc.x
+        y += alloc.y + alloc.height
         time = event.time
         print ("Button press : %d:%d" % (x, y))
-        self.proxy.call_sync('ButtonPress',
-                GLib.Variant('(iiiii)', (x, y, event.button, event.time, Gtk.PositionType.TOP,)),
-                Gio.DBusCallFlags.NO_AUTO_START, 500, None)
+        self.proxy.call_button_press_sync(x, y, event.button, event.time, Gtk.PositionType.TOP, None)
 
     def on_button_release(self, widget, event):
         # We're simulating a top panel here
-        x = widget.get_window().get_origin().x
-        y = widget.get_window().get_origin().y + widget.get_allocation().height
+        alloc = widget.get_allocation()
+        ignore, x, y = widget.get_window().get_origin()
+
+        x += alloc.x
+        y += alloc.y + alloc.height
         time = event.time
-        print ("Button press : %d:%d" % (x, y))
-        self.proxy.call_sync('ButtonRelease',
-                GLib.Variant('(iiiii)', (x, y, event.button, event.time, Gtk.PositionType.TOP,)),
-                Gio.DBusCallFlags.NO_AUTO_START, 500, None)
+        print ("Button release : %d:%d" % (x, y))
+        self.proxy.call_button_release_sync(x, y, event.button, event.time, Gtk.PositionType.TOP, None)
 
 class StatusApplet(GObject.Object):
 
@@ -80,71 +77,67 @@ class StatusApplet(GObject.Object):
         super(StatusApplet, self).__init__()
 
         self.window = Gtk.Window()
-        self.window.connect("destroy", Gtk.main_quit)
-        self.window.show()
+        self.window.set_accept_focus (False)
+        self.window.connect("destroy", self.on_window_destroy)
 
-        self.indicator_box = Gtk.Box()
-        self.window.add(self.indicator_box)
+        self.main_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL,
+                                margin=6,
+                                spacing=6)
+        self.window.add(self.main_box)
+
+        self.disco_button = Gtk.Button()
+        self.main_box.pack_start(self.disco_button, False, False, 0)
+        self.disco_button.connect("clicked", self.on_disco_button_clicked)
+
+        self.indicator_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
+                                     spacing=6)
+        self.main_box.pack_start(self.indicator_box, False, False, 0)
 
         self.indicators = {}
 
-        self.bus = Gio.bus_get_sync(Gio.BusType.SESSION)
+        self.monitor = None
+        self.setup_monitor()
 
-        # Register an Applet name on DBUS to let icons know there's at least one applet running
-        Gio.bus_own_name(Gio.BusType.SESSION,
-                         "org.x.StatusApplet.PID-%d" % os.getpid(),
-                         Gio.BusNameOwnerFlags.NONE,
-                         None,
-                         self.on_name_acquired,
-                         self.on_name_lost)
+        self.window.show_all()
 
-        self.dbus_proxy = Gio.DBusProxy.new_sync(self.bus,
-                                                 Gio.DBusProxyFlags.NONE,
-                                                 None,
-                                                 'org.freedesktop.DBus',
-                                                 '/org/freedesktop/DBus',
-                                                 'org.freedesktop.DBus',
-                                                 None)
-
-        self.refresh_status_items()
-        self.bus.signal_subscribe(None, "org.freedesktop.DBus", "NameOwnerChanged", None, None, 0, self.on_bus_changes, None)
-
-    def on_name_lost(self, connection, name, data=None):
-        print("DBus name couldn't be acquired!  Exiting...")
+    def on_window_destroy(self, widget, data=None):
+        self.destroy_monitor()
         Gtk.main_quit()
 
-    def on_name_acquired(self, connection, name, data=None):
-        print("Registering applet on DBUS: %s" % name)
+    def on_disco_button_clicked(self, widget, data=None):
+        if self.monitor == None:
+            self.setup_monitor ()
+        else:
+            self.destroy_monitor()
 
-    def refresh_status_items(self):
-        # Find all the status interfaces on the session bus
-        result = self.dbus_proxy.ListNames('()')
-        names = result
-        current_names = []
-        for name in names:
-            if name.startswith(DBUS_NAME):
-                current_names.append(name)
+    def setup_monitor (self):
+        self.monitor = XApp.StatusIconMonitor()
+        self.monitor.connect("icon-added", self.on_icon_added)
+        self.monitor.connect("icon-removed", self.on_icon_removed)
 
-        # Handle new names
-        for name in current_names:
-            if name not in self.indicators.keys():
-                print("Adding %s"  % name)
-                self.indicators[name] = StatusWidget(name, self.bus, self.dbus_proxy)
-                self.indicator_box.add(self.indicators[name])
-                self.window.show_all()
+        self.disco_button.set_label("Disconnect monitor")
 
-        # Handle names which vanishes
-        names_to_remove = []
-        for name in self.indicators.keys():
-            if name not in current_names:
-                names_to_remove.append(name)
-        for name in names_to_remove:
-            print("Removing %s" % name)
-            self.indicator_box.remove(self.indicators[name])
-            del(self.indicators[name])
+    def destroy_monitor (self):
+        for key in self.indicators.keys():
+            self.indicator_box.remove(self.indicators[key])
 
-    def on_bus_changes(self, connection, sender_name, object_path, interface_name, signal_name, parameters, user_data):
-        self.refresh_status_items()
+        self.monitor = None
+        self.indicators = {}
+
+        self.disco_button.set_label("Connect monitor")
+
+    def on_icon_added(self, monitor, proxy):
+        name = proxy.get_name()
+
+        self.indicators[name] = StatusWidget(proxy)
+        self.indicator_box.add(self.indicators[name])
+        self.window.show_all()
+
+    def on_icon_removed(self, monitor, proxy):
+        name = proxy.get_name()
+
+        self.indicator_box.remove(self.indicators[name])
+        del(self.indicators[name])
 
 if __name__ == '__main__':
     applet = StatusApplet()

--- a/test-scripts/xapp-status-icon
+++ b/test-scripts/xapp-status-icon
@@ -2,7 +2,7 @@
 
 import gi
 gi.require_version('XApp', '1.0')
-from gi.repository import XApp
+from gi.repository import XApp, Gtk, Gdk
 from gi.repository import GLib, GObject
 import sys
 
@@ -15,9 +15,19 @@ class App(GObject.Object):
         self.status_icon.set_icon_name("folder-symbolic")
         self.status_icon.set_tooltip_text("My tooltip text")
         self.status_icon.set_label("label 1")
+        self.status_icon.set_visible(True)
+
         self.counter = 1
         self.status_icon.connect("button-press-event", self.on_button_press)
         self.status_icon.connect("button-release-event", self.on_button_release)
+
+        self.menu = Gtk.Menu()
+        self.menu.append(Gtk.MenuItem.new_with_label("Engage the hyperdrive"))
+        self.menu.append(Gtk.SeparatorMenuItem())
+        self.menu.append(Gtk.MenuItem.new_with_label("It's a trap!"))
+        self.menu.show_all()
+
+        self.status_icon.set_menu(self.menu)
 
         GLib.timeout_add_seconds(2, self.on_timeout_cb)
 
@@ -32,6 +42,19 @@ class App(GObject.Object):
 
     def on_button_release(self, status_icon, x, y, button, time, position_type):
         print("Mouse button %d was released at %d %d" % (button, x, y))
+        if button == 3:
+            def position_menu_cb(menu, pointer_x, pointer_y, user_data):
+                [x, y, position] = user_data;
+                if (position_type == Gtk.PositionType.BOTTOM):
+                    y = y - menu.get_allocation().height;
+                if (position_type == Gtk.PositionType.RIGHT):
+                    x = x - menu.get_allocation().width;
+                return (x, y, False)
+
+            device = Gdk.Display.get_default().get_device_manager().get_client_pointer()
+
+            self.menu.popup_for_device(device, None, None, position_menu_cb, [x, y, position_type], button, 0)
+        return False
 
 if __name__ == '__main__':
     app = App()


### PR DESCRIPTION
- added monitor class (we can rename or whatever if desired)
- updated test applet to utilize new class

todo:
- (mostly done) Need to fix monitor handling click events (issue with introspection I need to fix first)
- Need to evaluate if any other handling should be done in this class (some menu handling?)
- (done)the status icon class should utilize the service part of the generated interface (will simplify some code)
- (done)need to have the status icon handle switching between Gtk and XApp better.
- add debugging info, document

related: https://github.com/linuxmint/cinnamon/pull/8836