### PR TITLE
Add some new features to the icon chooser dialog

### DIFF
--- a/libxapp/xapp-icon-chooser-dialog.c
+++ b/libxapp/xapp-icon-chooser-dialog.c
@@ -838,6 +838,48 @@ xapp_icon_chooser_dialog_set_default_icon (XAppIconChooserDialog *dialog,
 }
 
 /**
+ * xapp_icon_chooser_dialog_add_custom_category:
+ * @dialog: a #XAppIconChooserDialog
+ * @name: the name of the category as it will be displayed in the category list
+ * @icons: (transfer full) (element-type utf8): a list of icon names to add to the new category
+ *
+ * Adds a custom category to the dialog.
+ */
+void
+xapp_icon_chooser_dialog_add_custom_category   (XAppIconChooserDialog *dialog,
+                                                const gchar           *name,
+                                                GList                 *icons)
+{
+    XAppIconChooserDialogPrivate *priv;
+    IconCategoryInfo        *category_info;
+    GtkWidget               *row;
+    GtkWidget               *label;
+
+    priv = xapp_icon_chooser_dialog_get_instance_private (dialog);
+
+    category_info = g_new0 (IconCategoryInfo, 1);
+    category_info->name = name;
+    category_info->icons = icons;
+
+    category_info->model = gtk_list_store_new (3, G_TYPE_STRING, G_TYPE_STRING, GDK_TYPE_PIXBUF);
+    g_signal_connect (category_info->model, "row-inserted",
+                      G_CALLBACK (on_icon_store_icons_added), dialog);
+
+    category_info->icons = g_list_sort (category_info->icons, (GCompareFunc) g_utf8_collate);
+
+    row = gtk_list_box_row_new ();
+    label = gtk_label_new (category_info->name);
+    gtk_label_set_xalign (GTK_LABEL (label), 0.0);
+    gtk_widget_set_margin_start (GTK_WIDGET (label), 6);
+    gtk_widget_set_margin_end (GTK_WIDGET (label), 6);
+
+    gtk_container_add (GTK_CONTAINER (row), label);
+    gtk_container_add (GTK_CONTAINER (priv->list_box), row);
+
+    g_hash_table_insert (priv->categories, row, category_info);
+}
+
+/**
  * xapp_icon_chooser_dialog_get_icon_string:
  * @dialog: a #XAppIconChooserDialog
  *

--- a/libxapp/xapp-icon-chooser-dialog.c
+++ b/libxapp/xapp-icon-chooser-dialog.c
@@ -33,7 +33,6 @@ typedef struct
 {
     GtkResponseType  response;
     XAppIconSize     icon_size;
-    GtkListStore    *category_list;
     GtkListStore    *search_icon_store;
     GFileEnumerator *search_file_enumerator;
     GCancellable    *cancellable;
@@ -1064,7 +1063,7 @@ load_next_file_search_chunk (gpointer user_data)
 
     callback_info = (FileIconInfoLoadCallbackInfo*) user_data;
     priv = xapp_icon_chooser_dialog_get_instance_private (callback_info->dialog);
-   
+
     if (g_cancellable_is_cancelled (callback_info->cancellable))
     {
         free_file_info (callback_info);
@@ -1089,7 +1088,7 @@ load_next_category_chunk (gpointer user_data)
 
     callback_info = (NamedIconInfoLoadCallbackInfo*) user_data;
     priv = xapp_icon_chooser_dialog_get_instance_private (callback_info->dialog);
-   
+
     if (g_cancellable_is_cancelled (callback_info->cancellable))
     {
         free_named_info (callback_info);
@@ -1121,7 +1120,7 @@ load_next_name_search_chunk (gpointer user_data)
 
         return G_SOURCE_REMOVE;
     }
-   
+
     search_icon_name (callback_info->dialog,
                       priv->current_text,
                       priv->search_icon_store);
@@ -1381,7 +1380,7 @@ load_icons_for_category (XAppIconChooserDialog *dialog,
                 GtkIconInfo              *info;
 
                 info = gtk_icon_theme_lookup_icon (theme, name, icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
-                gtk_icon_info_load_icon_async (info, NULL, (GAsyncReadyCallback) (finish_pixbuf_load_from_name), callback_info);    
+                gtk_icon_info_load_icon_async (info, NULL, (GAsyncReadyCallback) (finish_pixbuf_load_from_name), callback_info);
             }
         }
         else
@@ -1648,7 +1647,7 @@ search_icon_name (XAppIconChooserDialog *dialog,
                     info = gtk_icon_theme_lookup_icon (theme, name, priv->icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
                     gtk_icon_info_load_icon_async (info, NULL, (GAsyncReadyCallback) (finish_pixbuf_load_from_name), callback_info);
                 }
-                
+
                 chunk_count++;
             }
         }

--- a/libxapp/xapp-icon-chooser-dialog.h
+++ b/libxapp/xapp-icon-chooser-dialog.h
@@ -43,6 +43,10 @@ gchar *                     xapp_icon_chooser_dialog_get_default_icon  (XAppIcon
 void                        xapp_icon_chooser_dialog_set_default_icon  (XAppIconChooserDialog *dialog,
                                                                         const gchar           *icon);
 
+void                        xapp_icon_chooser_dialog_add_custom_category   (XAppIconChooserDialog *dialog,
+                                                                            const gchar           *name,
+                                                                            GList                 *icons);
+
 G_END_DECLS
 
 #endif /* _XAPP_ICON_CHOOSER_DIALOG_H_ */

--- a/libxapp/xapp-icon-chooser-dialog.h
+++ b/libxapp/xapp-icon-chooser-dialog.h
@@ -38,6 +38,11 @@ void                        xapp_icon_chooser_dialog_add_button         (XAppIco
                                                                          GtkWidget             *button,
                                                                          GtkPackType            packing,
                                                                          GtkResponseType        response_id);
+
+gchar *                     xapp_icon_chooser_dialog_get_default_icon  (XAppIconChooserDialog *dialog);
+void                        xapp_icon_chooser_dialog_set_default_icon  (XAppIconChooserDialog *dialog,
+                                                                        const gchar           *icon);
+
 G_END_DECLS
 
 #endif /* _XAPP_ICON_CHOOSER_DIALOG_H_ */

--- a/test-scripts/xapp-icon-chooser-dialog
+++ b/test-scripts/xapp-icon-chooser-dialog
@@ -28,7 +28,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    dialog = XApp.IconChooserDialog(allow_paths=args.paths)
+    dialog = XApp.IconChooserDialog(allow_paths=args.paths, default_icon='folder')
     dialog.set_skip_taskbar_hint(False)
     if args.category:
         response = dialog.run_with_category(args.category)


### PR DESCRIPTION
* Adds a default_icon property which, when set, will cause the dialog to show a revert button. When that button is pressed, it will set the currently selected item to the default icon.
* Adds a *_add_custom_category () function which allows to specify a new category in the dialog's category list, which will (when selected) show the icons from the provided list of icon names.