### PR TITLE
xapp-icon-chooser-dialog.c: prevent segfault on non-existent icon name

### DIFF
--- a/libxapp/xapp-icon-chooser-dialog.c
+++ b/libxapp/xapp-icon-chooser-dialog.c
@@ -1500,6 +1500,13 @@ load_icons_for_category (XAppIconChooserDialog *dialog,
                 GtkIconInfo              *info;
 
                 info = gtk_icon_theme_lookup_icon (theme, name, icon_size, GTK_ICON_LOOKUP_FORCE_SIZE);
+                if (info == NULL)
+                {
+                    // this shouldn't be the case most of the time, but if a custom category is defined it's possible
+                    // the icon doesn't exist. In that case it's best to just skip over it since trying to load it will
+                    // lead to a segfault.
+                    continue;
+                }
                 gtk_icon_info_load_icon_async (info, NULL, (GAsyncReadyCallback) (finish_pixbuf_load_from_name), callback_info);
             }
         }


### PR DESCRIPTION
With the addition of the xapp_icon_chooser_dialog_add_custom_category it is now possible to have non-existent icon names. To prevent a segfault, these icon names are now skipped.