### PR TITLE
Cancel tasks before closing xapp-icon-chooser-dialog

### DIFF
--- a/libxapp/xapp-icon-chooser-dialog.c
+++ b/libxapp/xapp-icon-chooser-dialog.c
@@ -935,6 +935,8 @@ xapp_icon_chooser_dialog_close (XAppIconChooserDialog *dialog,
     priv = xapp_icon_chooser_dialog_get_instance_private (dialog);
 
     priv->response = response;
+    g_cancellable_cancel (priv->cancellable);
+    
     gtk_widget_hide (GTK_WIDGET (dialog));
 
     gtk_main_quit ();


### PR DESCRIPTION
Calls g_cancellable_cancel on xapp_icon_chooser_dialog_close
Closing the xapp-icon-chooser-dialog before the icon loading is completed result in crash due to use after free in the gtk application.

Fixes https://github.com/linuxmint/nemo/issues/3606

This was causing nemo to crash
nemo crash stack trace 

```c
(nemo:10040): Gtk-CRITICAL **: 22:26:18.409: gtk_list_store_append: assertion 'GTK_IS_LIST_STORE (list_store)' failed
(nemo:10040): Gtk-CRITICAL **: 22:26:18.409: gtk_list_store_set_valist: assertion 'GTK_IS_LIST_STORE (list_store)' failed
(nemo:10040): Gtk-CRITICAL **: 22:26:18.409: gtk_list_store_append: assertion 'GTK_IS_LIST_STORE (list_store)' failed
(nemo:10040): Gtk-CRITICAL **: 22:26:18.409: gtk_list_store_set_valist: assertion 'GTK_IS_LIST_STORE (list_store)' failed
(nemo:10040): Gtk-CRITICAL **: 22:26:18.409: gtk_widget_get_scale_factor: assertion 'GTK_IS_WIDGET (widget)' failed
sys:1: Warning: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
sys:1: Warning: g_hash_table_lookup: assertion 'hash_table != NULL' failed

Thread 1 "nemo" received signal SIGSEGV, Segmentation fault.
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:76
warning: 76	../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory
(gdb) bt
#0  __strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:76
#1  0x00007ffff77c2b2a in ??? () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#2  0x00007ffff77c66ad in ??? () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#3  0x00007ffff77c6cb1 in gtk_icon_theme_lookup_icon_for_scale () at /lib/x86_64-linux-gnu/libgtk-3.so.0
#4  0x00007ffff7f94481 in load_icons_for_category (dialog=0x55555814c570, category_info=0x555557b01140, icon_size=21845) at ../libxapp/xapp-icon-chooser-dialog.c:1499
#5  0x00007ffff7f93c19 in load_next_category_chunk (user_data=0x555558899e10) at ../libxapp/xapp-icon-chooser-dialog.c:1208
#6  0x00007ffff707449e in ??? () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#7  0x00007ffff70d3737 in ??? () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#8  0x00007ffff7073a63 in g_main_context_iteration () at /lib/x86_64-linux-gnu/libglib-2.0.so.0
#9  0x00007ffff72aa87d in g_application_run () at /lib/x86_64-linux-gnu/libgio-2.0.so.0
#10 0x0000555555591e0c in main (argc=2, argv=0x7fffffffdd78) at ../src/nemo-main.c:102
(gdb) f 4
#4  0x00007ffff7f94481 in load_icons_for_category (dialog=0x55555814c570, category_info=0x555557b01140, icon_size=21845) at ../libxapp/xapp-icon-chooser-dialog.c:1499
1499	                info = gtk_icon_theme_lookup_icon_for_scale (theme, name, icon_size, scale, GTK_ICON_LOOKUP_FORCE_SIZE);
(gdb) info local
info = 0x7fffffffdab0
context = 0x55555814c570
callback_info = 0x555558861240
name = 0x300 <error: Cannot access memory at address 0x300>
surface = 0x0
priv = 0x55555814c230
theme = 0x5555557c7920
chunk_count = 0
scale = 1

```
 