### PR TITLE
Add libgtk-layer-shell-dev to control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -59,6 +59,7 @@ Depends:
  libglib2.0-dev (>= 2.44),
  libgnomekbd-dev,
  libgtk-3-dev (>= 3.16),
+ libgtk-layer-shell-dev (>= 0.8),
  libxapp1 (= ${binary:Version}),
  libxkbfile-dev,
  ${misc:Depends},


### PR DESCRIPTION
Add dependency for libgtk-layer-shell-dev

../meson.build:41:14: ERROR: Dependency lookup for xapp with method 'pkgconfig' failed: Could not generate cflags for xapp:
Package gtk-layer-shell-0 was not found in the pkg-config search path.
Perhaps you should add the directory containing `gtk-layer-shell-0.pc'
to the PKG_CONFIG_PATH environment variable
Package 'gtk-layer-shell-0', required by 'xapp', not found