### PR TITLE
xapp-sn-watcher: Validate client-supplied icon pixmaps

### DIFF
--- a/xapp-sn-watcher/sn-item.c
+++ b/xapp-sn-watcher/sn-item.c
@@ -23,6 +23,10 @@
 
 #define FALLBACK_ICON_SIZE 24
 
+/* Sanity cap for client-supplied pixmap dimensions. Keeps the size math
+ * well inside the range of a gint. */
+#define MAX_PIXMAP_DIMENSION 4096
+
 typedef enum
 {
     STATUS_PASSIVE,
@@ -315,7 +319,7 @@ get_icon_surface (SnItem    *item,
                   GVariant  *pixmaps,
                   gchar    **md5)
 {
-    GVariantIter *iter;
+    GVariantIter *iter = NULL;
     cairo_surface_t *surface;
     gint width, height;
     gint largest_width, largest_height;
@@ -328,6 +332,17 @@ get_icon_surface (SnItem    *item,
 
     *md5 = NULL;
 
+    /* This comes straight off the bus. g_variant_get() with a mismatched
+     * format string leaves 'iter' untouched, so check the type before
+     * unpacking rather than after. */
+    if (!g_variant_is_of_type (pixmaps, G_VARIANT_TYPE ("a(iiay)")))
+    {
+        g_warning ("Ignoring icon pixmap for '%s': expected type 'a(iiay)' but got '%s'",
+                   item->sortable_name,
+                   g_variant_get_type_string (pixmaps));
+        return NULL;
+    }
+
     g_variant_get (pixmaps, "a(iiay)", &iter);
 
     if (iter == NULL)
@@ -337,12 +352,14 @@ get_icon_surface (SnItem    *item,
 
     while (g_variant_iter_loop (iter, "(ii@ay)", &width, &height, &byte_array_var))
     {
-        if (width > 0 && height > 0 && byte_array_var != NULL &&
+        if (width > 0 && height > 0 &&
+            width <= MAX_PIXMAP_DIMENSION && height <= MAX_PIXMAP_DIMENSION &&
+            byte_array_var != NULL &&
             ((width * height) > (largest_width * largest_height)))
         {
             gsize data_size = g_variant_get_size (byte_array_var);
 
-            if (data_size == width * height * 4)
+            if (data_size == (gsize) width * (gsize) height * 4)
             {
                 data = g_variant_get_data (byte_array_var);
 
@@ -353,7 +370,11 @@ get_icon_surface (SnItem    *item,
                         g_free (best_image_array);
                     }
 
+#if GLIB_CHECK_VERSION (2, 68, 0)
+                    best_image_array = g_memdup2 (data, data_size);
+#else
                     best_image_array = g_memdup (data, data_size);
+#endif
 
                     largest_data_size = data_size;
                     largest_width = width;


### PR DESCRIPTION
Any application on the session bus can crash xapp-sn-watcher (and with it
every tray icon on the panel) by exporting a StatusNotifierItem whose
IconPixmap property has the wrong type.

`get_icon_surface()` unpacks the property like this:

    GVariantIter *iter;                        /* uninitialized */
    g_variant_get (pixmaps, "a(iiay)", &iter); /* no-op on type mismatch */
    if (iter == NULL)                          /* reads uninitialized stack */
        return NULL;

When a client sends any signature other than `a(iiay)`, `g_variant_get()`
logs a critical and returns without touching `iter`, so the NULL check reads
an uninitialized stack slot and `g_variant_iter_loop()` dereferences garbage.
The same applies to AttentionIconPixmap and OverlayIconPixmap, which go
through the same function. The ToolTip handler already checks its type before
unpacking; the pixmap path does not.

This PR:

- checks the variant type before unpacking, and logs a warning naming the
  item and the offending type instead of crashing
- initializes the iterator so any future mismatch fails safe
- treats the pixmap geometry as untrusted: dimensions are capped at 4096
  (far above any real tray icon, far below anything that can overflow), and
  the size arithmetic is done in gsize, so `width * height * 4` can neither
  overflow a gint nor be truncated by `g_memdup()`'s guint length argument
- uses `g_memdup2()` on GLib >= 2.68, with the same version guard already
  used in xapp-gpu-offload-helper.c

Reproduced against master by registering an SNI client whose IconPixmap is
declared and returned as `ay`: the stock watcher segfaults as soon as it
fetches properties, the patched watcher logs

    Ignoring icon pixmap for ':1.10': expected type 'a(iiay)' but got 'ay'

and keeps running. Verified in a clean Ubuntu 24.04 environment on a private
session bus.

Found while investigating the tray instability Cinnamon users hit when
Signal and Slack shipped Electron 43.3.x/43.4.0 (electron/electron#52674,
signalapp/Signal-Desktop#7992). The Electron regression is fixed upstream in
43.4.1, but it demonstrated that one misbehaving client can take down the
whole tray; this closes the crash half of that. A follow-up PR addresses a
separate defect in how exiting clients' icons are removed.
