### PR TITLE
xapp-sn-watcher: Match bus names exactly when a client exits

### DIFF
--- a/xapp-sn-watcher/xapp-sn-watcher.c
+++ b/xapp-sn-watcher/xapp-sn-watcher.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <gtk/gtk.h>
 
@@ -88,21 +89,32 @@ handle_sn_item_name_owner_lost (XAppSnWatcher *watcher,
                                 const gchar   *old_owner)
 {
     GList *keys, *l;
+    gsize name_len;
+    gboolean removed_any = FALSE;
 
     keys = g_hash_table_get_keys (watcher->items);
+    name_len = strlen (name);
 
     for (l = keys; l != NULL; l = l->next)
     {
         const gchar *key = l->data;
 
-        if (g_str_has_prefix (key, name))
+        /* Keys are bus name + object path. A plain prefix test matches too
+         * much (":1.5" is a prefix of ":1.50/StatusNotifierItem"), so require
+         * the object path separator right after the name, and keep going, as
+         * one client may have registered more than one item. */
+        if (strncmp (key, name, name_len) == 0 && key[name_len] == '/')
         {
             DEBUG ("Client %s has exited, removing status icon", key);
             g_hash_table_remove (watcher->items, key);
 
-            update_published_items (watcher);
-            break;
+            removed_any = TRUE;
         }
+    }
+
+    if (removed_any)
+    {
+        update_published_items (watcher);
     }
 
     g_list_free (keys);


### PR DESCRIPTION
When a StatusNotifierItem client leaves the bus, the watcher finds the
client's items by prefix:

    if (g_str_has_prefix (key, name))

Item keys are the client's bus name concatenated with the item's object
path, so the prefix test matches more than the client that actually left:
":1.5" is a prefix of ":1.50/StatusNotifierItem", and "org.test.A0" is a
prefix of "org.test.A09/StatusNotifierItem". The loop also breaks on the
first match.

One bug, two symptoms:

- an exiting client can remove a different, still-running client's icon
- the icon belonging to the client that really did exit stays behind as a
  permanent phantom that nothing ever cleans up (it emits no signals and
  its bus name is already gone, so no future event touches it)

Reproduced against master with two well-behaved SNI clients on a private
session bus, named so that hash ordering exposes the bug:

    -- stock --
    before:  ['org.test.A0/StatusNotifierItem', 'org.test.A09/StatusNotifierItem']
    after:   ['org.test.A0/StatusNotifierItem']
    (org.test.A0 exited; org.test.A09 is STILL RUNNING)

    -- patched --
    before:  ['org.test.A0/StatusNotifierItem', 'org.test.A09/StatusNotifierItem']
    after:   ['org.test.A09/StatusNotifierItem']
    (org.test.A0 exited; org.test.A09 is STILL RUNNING)

Note that with other name pairs the same code can silently do the right
thing depending on hash iteration order, which makes this easy to miss in
casual testing.

The fix requires the object path separator immediately after the bus name
(object paths always start with '/', so this is exact), removes every
matching key instead of breaking on the first, and republishes the item
list once after the loop.

Found during the same investigation as #210 : the Electron
43.3.x/43.4.0 tray regression (electron/electron#52674) had Cinnamon users
restarting tray applications repeatedly, which is exactly the churn that
turns this into visibly vanishing and stuck icons.
