### PR TITLE
xapp-sn-watcher: Don't use the item after it has been disposed

### DIFF
--- a/xapp-sn-watcher/sn-item.c
+++ b/xapp-sn-watcher/sn-item.c
@@ -743,13 +743,14 @@ get_all_properties_callback (GObject      *source_object,
     GVariant     *value;
     properties = g_dbus_proxy_call_finish (G_DBUS_PROXY (source_object), res, &error);
 
+    item = SN_ITEM (user_data);
+
     if (g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
     {
         g_error_free (error);
+        g_object_unref (item);
         return;
     }
-
-    item = SN_ITEM (user_data);
 
     if (error != NULL)
     {
@@ -761,11 +762,13 @@ get_all_properties_callback (GObject      *source_object,
         }
 
         g_error_free (error);
+        g_object_unref (item);
         return;
     }
 
     if (properties == NULL)
     {
+        g_object_unref (item);
         return;
     }
 
@@ -945,6 +948,8 @@ get_all_properties_callback (GObject      *source_object,
 
     props_free (item->current_props);
     item->current_props = new_props;
+
+    g_object_unref (item);
 }
 
 static gboolean
@@ -952,6 +957,9 @@ update_all_properties (gpointer data)
 {
     SnItem *item = SN_ITEM (data);
 
+    /* The callback holds a reference across the async call. A client that
+     * exits while the call is in flight would otherwise have the item
+     * disposed out from under the callback. */
     g_dbus_proxy_call (item->prop_proxy,
                        "GetAll",
                        g_variant_new ("(s)",
@@ -960,7 +968,7 @@ update_all_properties (gpointer data)
                        5 * 1000,
                        item->cancellable,
                        get_all_properties_callback,
-                       item);
+                       g_object_ref (item));
 
     item->update_properties_timeout = 0;
 

--- a/xapp-sn-watcher/sn-item.c
+++ b/xapp-sn-watcher/sn-item.c
@@ -1157,10 +1157,11 @@ property_proxy_acquired (GObject      *source,
                          gpointer      user_data)
 {
     SnItem *item = SN_ITEM (user_data);
+    GDBusProxy *proxy;
     GError *error = NULL;
     gchar *json = NULL;
 
-    item->prop_proxy = g_dbus_proxy_new_finish (res, &error);
+    proxy = g_dbus_proxy_new_finish (res, &error);
 
     if (error != NULL)
     {
@@ -1169,10 +1170,14 @@ property_proxy_acquired (GObject      *source,
             g_critical ("Could not get property proxy for %s: %s\n",
                         g_dbus_proxy_get_name (item->sn_item_proxy),
                         error->message);
-            g_error_free (error);
-            return;
         }
+
+        g_error_free (error);
+        g_object_unref (item);
+        return;
     }
+
+    item->prop_proxy = proxy;
 
     g_signal_connect (item->sn_item_proxy,
                       "g-signal",
@@ -1195,11 +1200,16 @@ property_proxy_acquired (GObject      *source,
     update_conditionals (item);
 
     queue_update_properties (item, TRUE);
+
+    g_object_unref (item);
 }
 
 static void
 initialize_item (SnItem *item)
 {
+    /* The callback holds a reference across the async call. A client that
+     * registers and exits again before it completes would otherwise have the
+     * item disposed out from under the callback. */
     g_dbus_proxy_new (g_dbus_proxy_get_connection (item->sn_item_proxy),
                       G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES,
                       NULL,
@@ -1208,7 +1218,7 @@ initialize_item (SnItem *item)
                       "org.freedesktop.DBus.Properties",
                       item->cancellable,
                       property_proxy_acquired,
-                      item);
+                      g_object_ref (item));
 }
 
 SnItem *


### PR DESCRIPTION
property_proxy_acquired() has a use-after-free window on item teardown.
Found by reading during the same investigation as #210 and #211; there is
no deterministic reproducer, so the reasoning is spelled out below.

The watcher's hash table holds the only reference to an SnItem. When a
client leaves the bus, handle_sn_item_name_owner_lost() removes it and
dispose/finalize run immediately. But the g_dbus_proxy_new() call started
by initialize_item() holds no reference to the item, only a bare pointer
in user_data, and its callback may not have run yet. When it does:

- it writes item->prop_proxy through the freed pointer before looking at
  the error
- on G_IO_ERROR_CANCELLED it falls out of the error branch (there is no
  return on that path) and carries on connecting signals and building a
  status icon on the freed item, and leaks the GError as well

Any client that registers and exits again before the property proxy
arrives can hit this. A client stuck in a register/exit loop, which is
what a crashing tray app looks like, rolls those dice continuously.

Note that checking the error before touching the item would not be enough
on its own: cancellation is racy. If the async result was already queued
when sn_item_dispose() cancelled the cancellable, the callback runs with a
successful result and no CANCELLED error, on an item that is already gone.
The item has to stay alive until the callback has run.

The fix:

- initialize_item() passes g_object_ref (item) as callback data, so the
  in-flight call keeps the item alive; dispose is simply deferred until
  the callback drops its reference
- property_proxy_acquired() finishes into a local variable, inspects the
  error before touching the item, and returns cleanly on any error
  including cancellation (which also fixes the GError leak)

Verified that a build with this change compiles without warnings and that
items still register, publish, and are removed normally on a private
session bus.

Update: a second commit applies the same treatment to the GetAll call in
update_all_properties(). Its callback has the identical shape (bare item
pointer, guarded only by the cancellable) and the identical race: a client
that exits can have its GetAll failure queued before the watcher processes
NameOwnerChanged, so the callback runs after the item is freed and calls
g_dbus_proxy_get_name() through the freed pointer in the error branch.
This appears to be the crash in #189 and #194: both core dumps show SIGSEGV
in g_dbus_proxy_get_name called from watcher code inside a GIO async
completion, triggered by an application exiting.
